### PR TITLE
Show player's black ox statue as offtank color

### DIFF
--- a/Functions/threat.lua
+++ b/Functions/threat.lua
@@ -38,7 +38,19 @@ function Addon:UnitIsOffTanked(unit)
   end
 
   local target_of_unit = unitid .. "target"
-  return UnitIsUnit(target_of_unit, "pet") or ("TANK" == UnitGroupRolesAssigned(target_of_unit))
+  local targeting_statue = false
+
+  local _, player_class = UnitClass("player")
+  local spec = GetSpecialization()
+
+  if player_class == "MONK" and spec == SPEC_MONK_BREWMASTER then
+    local have_statue, statue_name = GetTotemInfo(1)
+    if have_statue then
+      targeting_statue = statue_name == UnitName(target_of_unit)
+    end
+  end
+
+  return targeting_statue or UnitIsUnit(target_of_unit, "pet") or ("TANK" == UnitGroupRolesAssigned(target_of_unit))
 end
 
 ---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Implements https://wow.curseforge.com/projects/tidy-plates-threat-plates/issues/270

Apparently the statue is treated as a totem, so it has no UnitID.  Have to do name comparisons instead; sucks, but oh well.