### PR TITLE
(9.1) Quest Widget fixes

### DIFF
--- a/Widgets/QuestWidget.lua
+++ b/Widgets/QuestWidget.lua
@@ -259,13 +259,14 @@ end
 function Widget:UNIT_QUEST_LOG_CHANGED()
   local QuestsToUpdate = self.QuestsToUpdate
 
-  for questIndex in pairs(QuestsToUpdate) do
-    self:UpdateQuestCacheEntry(questIndex)
-    QuestsToUpdate[questIndex] = false
-  end
+  if next(QuestsToUpdate) then
+    for questIndex in pairs(QuestsToUpdate) do
+      self:UpdateQuestCacheEntry(questIndex)
+      QuestsToUpdate[questIndex] = nil
+    end
 
-  QuestsToUpdate = {}
-  self:UpdateAllFramesAndNameplateColor()
+    self:UpdateAllFramesAndNameplateColor()
+  end
 end
 
 function Widget:QUEST_ACCEPTED(questIndex, questID)


### PR DESCRIPTION
Implemented BlackSalsafy's fix in for QuestsToUpdate

While testing this I found out that the questIndexes in the log change **alot** (sometimes even in or out of combat changes it). So the QuestsToUpdate now stores ID's rather then indexes so that update_log will always update the correct quest.