### PR TITLE
Hiding Guardian "pets" and Overriding of General "Hide Nameplate" Settings with Custom Nameplates

### DIFF
--- a/Constants.lua
+++ b/Constants.lua
@@ -279,9 +279,7 @@ local TOTEM_DATA_RETAIL = {
   { SpellID = 204330, ID = "P2", GroupColor = "2b76ff"},	  -- Skyfury Totem
   { SpellID = 204336, ID = "P4", GroupColor = "2b76ff"},	  -- Grounding Totem
 
-  --{ SpellID = 204332, ID = "P3", GroupColor = "2b76ff"},	  -- Windfury Totem (removed in patch 8.0.1)p
   --{ SpellID = 196932, ID = "N6", GroupColor = "4c9900"},		-- Voodoo Totem (removed in patch 8.0.1)
-  --{ SpellID = 192058, ID = "N3", GroupColor = "4c9900"},		-- Lightning  Surge Totem (renamed to Capacitator Totem in patch 8.0.1)
 }
 
 local TOTEM_DATA_CLASSIC = {
@@ -771,6 +769,7 @@ ThreatPlates.DEFAULT_SETTINGS = {
     },
     uniqueWidget = {
       ON = true,
+      override = true,
       scale = 22, -- old default: 35,
       x = 0,
       y = 30, -- old default:  24,

--- a/Constants.lua
+++ b/Constants.lua
@@ -496,6 +496,7 @@ ThreatPlates.DEFAULT_SETTINGS = {
       HideElite = false,
       HideTapped = false,
       HideFriendlyInCombat = false,
+      HideGuardian = false,
     },
     castbarColor = {
       -- toggle = true, -- removed in 8.7.0

--- a/Options.lua
+++ b/Options.lua
@@ -4431,6 +4431,7 @@ local function CreateVisibilitySettings()
           HideElite = { name = L["Rares & Elites"], order = 2, type = "toggle", arg = { "Visibility", "HideElite" }, },
           HideBoss = { name = L["Bosses"], order = 3, type = "toggle", arg = { "Visibility", "HideBoss" }, },
           HideTapped = { name = L["Tapped Units"], order = 4, type = "toggle", arg = { "Visibility", "HideTapped" }, },
+		  HideGuardian = { name = L["Guardian Units"], order = 5, type = "toggle", arg = { "Visibility", "HideGuardian" }, },
           ModeHideFriendlyInCombat = {
             name = L["Friendly Units in Combat"],
             order = 10,

--- a/Options.lua
+++ b/Options.lua
@@ -7134,6 +7134,21 @@ local function CreateCustomNameplatesGroup()
       type = "group",
       order = 30,
       args = {
+		General = {
+          name = L["General"],
+          type = "group",
+          order = 1,
+          inline = true,
+          args = {
+			Override = {
+				name = L["Override General Hide Settings"],
+				type = "toggle",
+				order = 1,
+				desc = 'Toggle this option if you want the custom nameplates to be able to override general settings (e.g. the "Hide Nameplate" settings)',
+				arg = { "uniqueWidget", "override" }
+			},
+          },
+        },
         Icon = {
           name = L["Icon"],
           type = "group",

--- a/Styles/Styles.lua
+++ b/Styles/Styles.lua
@@ -321,21 +321,33 @@ end
 function Addon:SetStyle(unit)
   local show, headline_view = ShowUnit(unit)
 
-  if not show then
-    return "empty", nil
-  end
+  local db_base = TidyPlatesThreat.db.profile
+  local db = db_base.uniqueWidget
 
+  if not db.override then
+	  if not show then
+		return "empty", nil
+	  end
+  end
+  
   -- Check if custom nameplate should be used for the unit:
   local style
   if unit.CustomStyleCast then
-    style = unit.CustomStyleCast
-    unit.CustomPlateSettings = unit.CustomPlateSettingsCast
+	style = unit.CustomStyleCast
+	unit.CustomPlateSettings = unit.CustomPlateSettingsCast
   elseif unit.CustomStyleAura then
-    style = unit.CustomStyleAura
-    unit.CustomPlateSettings = unit.CustomPlateSettingsAura
+	style = unit.CustomStyleAura
+	unit.CustomPlateSettings = unit.CustomPlateSettingsAura
   else
-    style = UnitStyle_NameDependent(unit) or (headline_view and "NameOnly")
+	style = UnitStyle_NameDependent(unit) or (headline_view and "NameOnly")
   end
+	  
+  if db.override then
+	if not show and not (style ~= nil and not (type(style) == string and (style == "unique"))) then
+		return "empty", nil
+	end
+  end
+	
 
   -- Dynamic enable checks for custom styles
   -- Only check it once if custom style is used for multiple mobs

--- a/Styles/Styles.lua
+++ b/Styles/Styles.lua
@@ -140,11 +140,11 @@ local function ShowUnit(unit)
 
   if not show then return false end
 
-  local e, b, t = (unit.isElite or unit.isRare), unit.isBoss, _G.UnitIsTapDenied(unit.unitid)
+  local e, b, t, g = (unit.isElite or unit.isRare), unit.isBoss, _G.UnitIsTapDenied(unit.unitid), (not UnitIsPlayer(unit.unitid) and UnitPlayerControlled(unit.unitid) and not UnitIsOtherPlayersPet(unit.unitid))
   local db_base = TidyPlatesThreat.db.profile
   local db = db_base.Visibility
 
-  if (e and db.HideElite) or (b and db.HideBoss) or (t and db.HideTapped) then
+  if (e and db.HideElite) or (b and db.HideBoss) or (t and db.HideTapped) or (g and db.HideGuardian) then
     return false
   elseif db.HideNormal and not (e or b) then
     return false

--- a/Widgets/ComboPointsWidget.lua
+++ b/Widgets/ComboPointsWidget.lua
@@ -212,7 +212,6 @@ if Addon.CLASSIC then
       self.UnitPowerMax = 0
     end
   end
-  GetUnitChargedPowerPoints = function(...) return nil end
 else
   function Widget:DetermineUnitPower()
     local power_type = UNIT_POWER[PlayerClass]


### PR DESCRIPTION
Hello,

This PR accomplishes two things:
- Adds the option to hide "Guardian" units (more on why this is "needed" below)
- Enables the user to override the general "Hide Nameplates" options with custom nameplates, if wanted (with a toggle).

There are many situations in which a player may want to see a few guardian units, but not the vast majority. E.g. in PvP a user may want to hide Mirror Image or Earth, Storm, and Fire clones (which do not have distinct names, they have the same name as their caster) and most other guardians, whereas Abomination and a few others are very important to see.

In such situations a whitelist approach is wanted. 

The CVar for "Show Enemy Guardian Units" can in this scenario not be turned off (as some guardians must be shown), but a generic "Hide Guardian Units" can be used to enable a whitelist/blacklist-like behaviour when used in combination with custom plates. Lastly, an option for "Allow overriding of general hidden nameplate options" was added for more customization (disabling any residual/long forgotten custom plates from showing if the general option of hiding has been chosen).  