### PR TITLE
ThreatPlates-309 - Update options pane to use new Backdrop API

### DIFF
--- a/Libs/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
+++ b/Libs/AceConfig-3.0/AceConfigDialog-3.0/AceConfigDialog-3.0.lua
@@ -545,7 +545,7 @@ end
 do
 	local frame = AceConfigDialog.popup
 	if not frame then
-		frame = CreateFrame("Frame", nil, UIParent)
+		frame = CreateFrame("Frame", nil, UIParent, BackdropTemplateMixin and "BackdropTemplate")
 		AceConfigDialog.popup = frame
 		frame:Hide()
 		frame:SetPoint("CENTER", UIParent, "CENTER")


### PR DESCRIPTION
Simple update to address https://github.com/Backupiseasy/ThreatPlates/issues/309, utilizing the updated Backdrop API introduced with [WoW cilent 9.0.1](https://github.com/Stanzilla/WoWUIBugs/wiki/9.0.1-Consolidated-UI-Changes#lua-changes)

There's probably a better way to do this, but I'm not sure where to start with contributing to AceConfig.

Fixes #309