### PR TITLE
SOD Nameplate Castbar Fixes

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -359,7 +359,20 @@ function TidyPlatesThreat:OnInitialize()
   Addon.LibSharedMedia = LibStub("LibSharedMedia-3.0")
   Addon.LibCustomGlow = LibStub("LibCustomGlow-1.0")
 
-  if Addon.IS_CLASSIC then
+  if Addon.IS_CLASSIC_SOD then
+    Addon.LibClassicDurations = LibStub("LibClassicDurations")
+
+    Addon.LibClassicCasterino = LibStub("LibClassicCasterino-ThreatPlates")
+    -- Register callsbacks for spellcasting library
+    self:RegisterEvent("UNIT_SPELLCAST_START", Addon.UNIT_SPELLCAST_START)
+    self:RegisterEvent("UNIT_SPELLCAST_DELAYED", Addon.UnitSpellcastMidway) -- only for player
+    self:RegisterEvent("UNIT_SPELLCAST_STOP", Addon.UNIT_SPELLCAST_STOP)
+    self:RegisterEvent("UNIT_SPELLCAST_FAILED", Addon.UNIT_SPELLCAST_STOP)
+    self:RegisterEvent("UNIT_SPELLCAST_INTERRUPTED", Addon.UNIT_SPELLCAST_INTERRUPTED)
+    Addon.LibClassicCasterino.RegisterCallback(self,"UNIT_SPELLCAST_CHANNEL_START", Addon.UNIT_SPELLCAST_CHANNEL_START)
+    Addon.LibClassicCasterino.RegisterCallback(self,"UNIT_SPELLCAST_CHANNEL_UPDATE", Addon.UnitSpellcastMidway) -- only for player
+    Addon.LibClassicCasterino.RegisterCallback(self,"UNIT_SPELLCAST_CHANNEL_STOP", Addon.UNIT_SPELLCAST_CHANNEL_STOP)
+  elseif Addon.IS_CLASSIC then
     Addon.LibClassicDurations = LibStub("LibClassicDurations")
 
     Addon.LibClassicCasterino = LibStub("LibClassicCasterino-ThreatPlates")

--- a/Init.lua
+++ b/Init.lua
@@ -24,6 +24,7 @@ local UnitDetailedThreatSituation = UnitDetailedThreatSituation
 -- WoW Version Check
 ---------------------------------------------------------------------------------------------------
 Addon.IS_CLASSIC = (WOW_PROJECT_ID == WOW_PROJECT_CLASSIC)
+Addon.IS_CLASSIC_SOD = (Addon.IS_CLASSIC and (select(4, GetBuildInfo()) >= 11500))
 Addon.IS_TBC_CLASSIC = (GetClassicExpansionLevel and GetClassicExpansionLevel() == LE_EXPANSION_BURNING_CRUSADE)
 Addon.IS_WRATH_CLASSIC = (GetClassicExpansionLevel and GetClassicExpansionLevel() == LE_EXPANSION_WRATH_OF_THE_LICH_KING)
 Addon.IS_MAINLINE = (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE)
@@ -136,8 +137,12 @@ if Addon.IS_CLASSIC or Addon.IS_TBC_CLASSIC or Addon.IS_WRATH_CLASSIC then
 
     return is_tanking, status, threatpct, rawthreatpct, threat_value
   end
+
+	-- Not available in Classic
+	Addon.IsSoloShuffle = function() return false end
 else
 	Addon.UnitDetailedThreatSituationWrapper = UnitDetailedThreatSituation
+	Addon.IsSoloShuffle = C_PvP.IsSoloShuffle
 end
 
 ---------------------------------------------------------------------------------------------------

--- a/Libs/LibClassicCasterino/LibClassicCasterino.lua
+++ b/Libs/LibClassicCasterino/LibClassicCasterino.lua
@@ -613,7 +613,8 @@ classChannelsByAura = {
     [18807] = 3,    -- Mind Flay
     [2096] = 60,    -- Mind Vision
     [10912] = 3,    -- Mind Control
-
+    
+    
     -- WARLOCK
     [126] = 45,       -- Eye of Kilrogg
     [11700] = 5,    -- Drain Life
@@ -631,6 +632,8 @@ classChannelsByCast = {
 
     -- MAGE
     [25345] = 5,     -- Arcane Missiles
+    -- Priest
+    [402289] = 1,   -- Penance
 }
 
 


### PR DESCRIPTION
Hey ! 
In SOD many of the spell ids got switched around which confuses LibClassicCasterino so it does not show all casts.

The good news is that technically you dont need LibClassicCasterino at all anymore since you can just listen to the events and use the UnitCastingInfo / UnitChannelInfo directly from the WoW API.

The bad news is that the UnitChannelInfo Event is bugged and only returns a bunch of nils, so we still need LibClassicCasterino for that. 

I added penance as a new channel to show show  how it is done.