### PR TITLE
fix: Added initial variables to "local CalculateSynchedNameplateSize function"

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -75,14 +75,14 @@ if Addon.WOW_USES_CLASSIC_NAMEPLATES then
 else 
   local function CalculateSynchedNameplateSize(width_key, height_key)
     local db = Addon.db.profile.settings
+    local width = db.frame[width_key]
+    local height = db.frame[height_key]
+
     if db.frame.SyncWithHealthbar then
       -- This functions were interpolated from ratio of the clickable area and the Blizzard nameplate healthbar
       -- for various sizes
       width = db.healthbar[width_key] + 24.5
       height = (db.healthbar[height_key] + 11.4507) / 0.347764  
-    else
-      width = db.frame[width_key]
-      height = db.frame[height_key]
     end
   
     -- Update values in settings, so that the options dialog (clickable area) shows the correct values


### PR DESCRIPTION
I tracked down a bug, which first started appearing in 12.0.0-beta3, the exact commit hash is d9a9004.
The issue was that some weakaura icons would grow unexpectedly large (see the image).
As I was checking the changes I found that some initial values were not set in the mentioned function.

![image](https://github.com/user-attachments/assets/1428670a-e362-4bd2-9018-6054d1f8d8ab)
