### PR TITLE
Make Custom Styles work with player names (rebased to develop)

### DIFF
--- a/Styles/Styles.lua
+++ b/Styles/Styles.lua
@@ -207,7 +207,7 @@ function Addon.UnitStyle_NameDependent(unit)
   local db = Addon.db.profile
 
   local plate_style, custom_style, totem_settings
-  local name_custom_style = NameTriggers[unit.name] or NameTriggers[unit.NPCID]
+  local name_custom_style = NameTriggers[unit.name] or NameTriggers[unit.NPCID] or NameTriggers[unit.basename]
   if name_custom_style and name_custom_style.Enable.UnitReaction[unit.reaction] then
     custom_style = name_custom_style
     plate_style = GetStyleForPlate(custom_style)

--- a/TidyPlatesInternal/TidyPlatesCore.lua
+++ b/TidyPlatesInternal/TidyPlatesCore.lua
@@ -638,7 +638,7 @@ do
 
     Addon:UpdateUnitIdentity(unit, unitid)
 
-    unit.name = SetUnitAttributeName(unitid, unit.type)
+    unit.name, unit.basename = SetUnitAttributeName(unitid, unit.type)
     unit.isCasting = false
     unit.IsInterrupted = false
     visual.castbar.FlashTime = 0  -- Set FlashTime to 0 so that the castbar is actually hidden (see statusbar OnHide hook function OnHideCastbar)

--- a/TidyPlatesInternal/TidyPlatesCore.lua
+++ b/TidyPlatesInternal/TidyPlatesCore.lua
@@ -423,6 +423,8 @@ end
 
 local function SetUnitAttributeName(unitid, unit_type)
   local unit_name, realm = UnitName(unitid)
+  -- Let's preserve the unaltered name for the custom styles check…
+  local unit_basename = unit_name
 
   if unit_type == "PLAYER" then
     local db = Addon.db.profile.settings.name
@@ -435,8 +437,11 @@ local function SetUnitAttributeName(unitid, unit_type)
       unit_name = unit_name .. " - " .. realm
     end
   end
+  
+  -- …but only generate a new unit.basename field when needed
+  if unit_basename == unit_name then unit_basename = nil end
 
-  return unit_name
+  return unit_name, unit_basename
 end
 
 local function SetUnitAttributeTarget(unit)


### PR DESCRIPTION
Rebased version of this PR: https://github.com/Backupiseasy/ThreatPlates/pull/601

---

If we assume that the user expects to enter a player name in order to trigger the Custom Style on a player with that name, then this undertaking will fail with any of these user settings:

- player names are set to show title
- player names are set to show realm

With these settings, the user would have to enter the _complete displayed player name & title_ (aka UnitPVPName), or the _player name & realm name_, or _both combined_, in the name field of the Custom Style.

__Purpose of the PR is to make names entered as a pattern in Custom Styles match against the base player names, without title or realm.__

While there might be some legit reasoning for the realm name (to distinguish players with the same name), I can’t see any reasoning for the title, especially because the title can change at any time.

The proposed solution still keeps your evaluation order of 1) `unit.name` and 2) `unit.NPCID`, and just adds 3) `unit.basename` at the end (Styles.lua, L210).

This means:

- a simple player name (w/o ttile/realm) can be a match now
- existing user patterns of `<player name>-<realm name>`, or `<player name & title combo>` are still valid
- if the user wants to distinguish player names by realm, he still can do so by entering `<player name>-<realm name>`; as long as he doesn't have a pattern for just `<player name>`, this will be a unique, realmname-specific, match
