### PR TITLE
Update Delves for 11.2, plus missing Undermine boss delve

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -563,11 +563,11 @@ end
 -- To avoid redundant calls, make sure to only add instance IDs here that do not trigger the PLAYER_ENTERING_WORLD event.
 local WalkInInstances = {
   -- Delves
+  -- TWW Vanilla
   ["2664"] = true, -- Fungal Folly
   ["2679"] = true, -- Mycomancer Cavern
   ["2680"] = true, -- Earthcrawl Mines
   ["2681"] = true, -- Kriegval's Rest
-  ["2682"] = true, -- Zekvir's Lair ; TODO: check this one, if it behaves like the others
   ["2683"] = true, -- The Waterworks
   ["2684"] = true, -- The Dread Pit
   ["2685"] = true, -- Skittering Breach
@@ -578,9 +578,15 @@ local WalkInInstances = {
   ["2690"] = true, -- The Underkeep
   ["2767"] = true, -- The Sinkhole
   ["2768"] = true, -- Tak-Rethan Abyss
+  ["2836"] = true, -- Earthcrawl Mines
+  ["2682"] = true, -- Zekvir's Lair; boss delve
+  -- TWW Undermine
   ["2815"] = true, -- Excavation Site 9
   ["2826"] = true, -- Sidestreet Sluice
-  ["2836"] = true, -- Earthcrawl Mines
+  ["2831"] = true, -- Demolition Dome; boss delve
+  -- TWW Karesh
+  ["2803"] = true, -- Archival Assault
+  ["2951"] = true, -- Voidrazor Sanctuary; boss delve
 }
 
 function TidyPlatesThreat:PLAYER_MAP_CHANGED(_, previousID, currentID)


### PR DESCRIPTION
Just a little update to my hardcoded WalkInInstances (currently only Delves; implemented with https://github.com/Backupiseasy/ThreatPlates/pull/593). Sorry for the delay.

To answer my own question/doubt from the (now removed) comment in the code: The boss delves (e.g. Zekvir's Lair) also do _not_ fire a PLAYER_ENTERING_WORLD event on enter or leave, i.e., they behave consistently with "regular" delves; probably they just are regular delves.

They do fire the PLAYER_MAP_CHANGED event, followed by ACTIVE_DELVE_DATA_UPDATE and  WALK_IN_DATA_UPDATE on enter, and the PLAYER_MAP_CHANGED on leave.

---

Have you thought about my suggestion to generally use PLAYER_MAP_CHANGED instead of PLAYER_ENTERING_WORLD (to get rid of the hardcoded table), as detailed in https://github.com/Backupiseasy/ThreatPlates/pull/593#issuecomment-3146530700?
