### PR TITLE
Fix Lua error breaking enemy nameplate coloring in Arena

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
 # @project-version@ (@build-time@)
 
-* Fixed a Lua error in the Auras widget when aura highlighting was enabled [GH-719].
-* Updated integrated libraries (LibCustomGlow to 1.0.4-10-g4f8f5c2-alpha).
+* Fixed a Lua error that broke enemy nameplate coloring in Arenas and Rated Solo Shuffle on Midnight [GH-724].

--- a/Modules/Color.lua
+++ b/Modules/Color.lua
@@ -12,6 +12,7 @@ local abs, floor, ceil, pairs = abs, floor, ceil, pairs
 
 -- WoW APIs
 local UnitIsPVP, UnitPlayerControlled = UnitIsPVP, UnitPlayerControlled
+local GetClassColor = C_ClassColor.GetClassColor
 
 -- WoW Classic APIs:
 
@@ -19,6 +20,7 @@ local UnitIsPVP, UnitPlayerControlled = UnitIsPVP, UnitPlayerControlled
 local SubscribeEvent, PublishEvent = Addon.EventService.Subscribe, Addon.EventService.Publish
 local StyleModule = Addon.Style
 local RGB_P = Addon.RGB_P
+local IsSecretValueTP = Addon.IsSecretValue
 
 -- Global vars/functions that we don't upvalue since they might get hooked, or upgraded
 -- List them here for Mikk's FindGlobals script
@@ -226,12 +228,23 @@ local GetColorByHealth = ColorModule.GetColorByHealthDeficit
 -- Color by class
 ---------------------------------------------------------------------------------------------------
 
+-- unit.class can be a secret value for enemy players in restricted contexts (e.g., arena/rated PvP on
+-- Midnight), so it cannot be used as a SettingsBase.Colors.Classes table key. C_ClassColor.GetClassColor
+-- accepts a secret class token as a safe C-API sink and returns Blizzard's default class color instead.
+local function GetColorForClass(class)
+  if IsSecretValueTP(class) then
+    return GetClassColor(class)
+  end
+
+  return SettingsBase.Colors.Classes[class]
+end
+
 local function GetColorByClass(unit, plate_style)
   local color
 
   if unit.type == "PLAYER" then
     if unit.reaction == "HOSTILE" then
-      color = SettingsBase.Colors.Classes[unit.class]
+      color = GetColorForClass(unit.class)
     elseif unit.reaction == "FRIENDLY" then
       local db_social = SettingsBase.socialWidget
       if db_social.ShowFriendColor and Addon:IsFriend(unit, plate_style) then
@@ -239,7 +252,7 @@ local function GetColorByClass(unit, plate_style)
       elseif db_social.ShowGuildmateColor and Addon:IsGuildmate(unit, plate_style) then
         color = db_social.GuildmateColor
       else
-        color = SettingsBase.Colors.Classes[unit.class]
+        color = GetColorForClass(unit.class)
       end
     end
   end

--- a/TidyPlates_ThreatPlates_Changes.log
+++ b/TidyPlates_ThreatPlates_Changes.log
@@ -1,4 +1,9 @@
 ﻿------------------------------------------------------
+13.0.31 (2026-08-13)
+------------------------------------------------------
+* Fixed a Lua error that broke enemy nameplate coloring in Arenas and Rated Solo Shuffle on Midnight [GH-724].
+
+------------------------------------------------------
 13.0.30 (2026-08-11)
 ------------------------------------------------------
 * Fixed a Lua error in the Auras widget when aura highlighting was enabled [GH-719].


### PR DESCRIPTION
## Summary
- `unit.class` can be a secret value for enemy players in restricted PvP contexts (arena, rated solo shuffle) on Midnight, which crashed `GetColorByClass` when used as a table key.
- Added `GetColorForClass` helper: uses `C_ClassColor.GetClassColor` (a safe C-API sink for secret values) when the class token is secret, falls back to the configured `SettingsBase.Colors.Classes` lookup otherwise.

Fixes #724

## Test plan
- [ ] Enter Arena Skirmish / Rated Solo Shuffle on Midnight with "Color by Class" enabled for enemy healthbar/name.
- [ ] Confirm no `Color.lua` Lua errors appear in BugSack.
- [ ] Confirm enemy nameplates render with a class color instead of freezing/erroring.