### PR TITLE
Fix 12.1 GetAuraSlots secret-aura taint in Auras widget

### DIFF
--- a/Widgets/AurasWidgetMidnight.lua
+++ b/Widgets/AurasWidgetMidnight.lua
@@ -1,5 +1,9 @@
 ---------------------------------------------------------------------------------------------------
--- Auras Widget
+-- Auras Widget (Midnight / 12.1+)
+--
+-- Patch 12.1 makes C_UnitAuras.GetAuraSlots / AuraUtil.ForEachAura error while auras are secret
+-- (combat, encounters, M+, PvP) and the caller is tainted. Display auras through Blizzard's
+-- AuraContainer / AuraButton APIs instead of reading aura data in Lua.
 ---------------------------------------------------------------------------------------------------
 local ADDON_NAME, Addon = ...
 
@@ -11,784 +15,647 @@ local Widget = Addon.Widgets:NewWidget("Auras")
 -- Imported functions and constants
 ---------------------------------------------------------------------------------------------------
 
--- Lua APIs
-local GetTime = GetTime
-local pairs = pairs
-local floor, ceil, min = floor, ceil, min
-local sort = sort
+local pairs, ipairs = pairs, ipairs
+local min, max = min, max
 local tonumber = tonumber
+local tinsert = table.insert
 
--- WoW APIs
-local GetFramerate = GetFramerate
-local IsAuraFilteredOutByInstanceID, GetAuraDuration = C_UnitAuras.IsAuraFilteredOutByInstanceID, C_UnitAuras.GetAuraDuration
-local GetAuraApplicationDisplayCount = C_UnitAuras.GetAuraApplicationDisplayCount
-local GetAuraDispelTypeColor = C_UnitAuras.GetAuraDispelTypeColor
-local AuraBarInterpolation = Enum.StatusBarInterpolation and Enum.StatusBarInterpolation.Immediate
-local RemainingTimeDirection = Enum.StatusBarTimerDirection and Enum.StatusBarTimerDirection.RemainingTime
+local CreateFrame = CreateFrame
+local InCombatLockdown = InCombatLockdown
 
--- ThreatPlates APIs
-local AnimationStopFlash, AnimationFlash = Addon.Animation.StopFlash, Addon.Animation.Flash
 local FontUpdateText = Addon.Font.UpdateText
-local AuraTriggerInitialize, AuraTriggerUpdateStyle = Addon.Style.AuraTriggerInitialize, Addon.Style.AuraTriggerUpdateStyle
-local CUSTOM_GLOW_FUNCTIONS, CUSTOM_GLOW_WRAPPER_FUNCTIONS = Addon.CUSTOM_GLOW_FUNCTIONS, Addon.CUSTOM_GLOW_WRAPPER_FUNCTIONS
-local BackdropTemplate = Addon.BackdropTemplate
 local MODE_FOR_STYLE, AnchorFrameTo = Addon.MODE_FOR_STYLE, Addon.AnchorFrameTo
-local IsSecretValueTP, EvaluateColorValueFromBoolean = Addon.IsSecretValue, Addon.EvaluateColorValueFromBoolean
 local UnitIsUnitTP = Addon.UnitIsUnit
-
-local _G =_G
--- Global vars/functions that we don't upvalue since they might get hooked, or upgraded
--- List them here for Mikk's FindGlobals script
--- GLOBALS: CreateFrame, UnitAffectingCombat
+local AuraTriggerInitialize, AuraTriggerUpdateStyle = Addon.Style.AuraTriggerInitialize, Addon.Style.AuraTriggerUpdateStyle
 
 ---------------------------------------------------------------------------------------------------
--- Constants
+-- AuraContainer availability
 ---------------------------------------------------------------------------------------------------
 
-local GRID_LAYOUT = {
-  LEFT = {
-    BOTTOM =  { "BOTTOMLEFT", "BOTTOMRIGHT", "BOTTOMLEFT", "TOPLEFT"   ,    1,  1},
-    TOP    =  { "BOTTOMLEFT", "BOTTOMRIGHT", "TOPLEFT",    "BOTTOMLEFT",    1, -1},
-  },
-  RIGHT = {
-    BOTTOM =  { "BOTTOMRIGHT", "BOTTOMLEFT", "BOTTOMRIGHT", "TOPRIGHT",    -1,  1},
-    TOP    =  { "TOPRIGHT"   , "TOPLEFT",    "TOPRIGHT",    "BOTTOMRIGHT", -1, -1},
-  },
-}
+local HAS_AURA_CONTAINER = C_XMLUtil and C_XMLUtil.GetTemplateInfo and C_XMLUtil.GetTemplateInfo("CustomAuraContainerTemplate")
+
+local FlowDirection = AnchorUtil and AnchorUtil.FlowDirection
+local SortMethod = AuraContainerSortMethod
+local SortDirection = AuraContainerSortDirection
+local DispelStyle = Enum.CustomAuraButtonDispelTypeTextureStyle
+local ShouldAurasBeSecret = C_Secrets and C_Secrets.ShouldAurasBeSecret
+
+local GROUP_KEYS = { "Main", "Mine", "Important", "Dispellable", "CrowdControl", "Whitelist" }
+
+---------------------------------------------------------------------------------------------------
+-- Cached configuration
+---------------------------------------------------------------------------------------------------
 
 Widget.TEXTURE_BORDER = Addon.ADDON_DIRECTORY .. "Artwork\\squareline"
 
--- Debuffs are color coded, with poison debuffs having a green border, magic debuffs a blue border, diseases a brown border,
--- urses a purple border, and physical debuffs a red border
-Widget.AURA_TYPE = { Curse = 1, Disease = 2, Magic = 3, Poison = 4, }
+Widget.Buffs = { CenterAurasPositions = {} }
+Widget.Debuffs = { CenterAurasPositions = {} }
+Widget.CrowdControl = { CenterAurasPositions = {} }
 
-Widget.ANCHOR_POINT_SETPOINT = Addon.ANCHOR_POINT_SETPOINT
-
--- Aura Grids
-Widget.Buffs = {
-  CenterAurasPositions = {},
-}
-Widget.Debuffs = {
-  CenterAurasPositions = {}
-}
-Widget.CrowdControl = {
-  CenterAurasPositions = {}
-}
-
----------------------------------------------------------------------------------------------------
--- Crowd Control Auras
----------------------------------------------------------------------------------------------------
-
-local CROWD_CONTROL_SPELLS_BY_EXPANSION = {
-  MAINLINE = {},
-}
-
-Widget.CROWD_CONTROL_SPELLS = CROWD_CONTROL_SPELLS_BY_EXPANSION[Addon.GetExpansionLevel()]
-
----------------------------------------------------------------------------------------------------
--- Global attributes
----------------------------------------------------------------------------------------------------
---local PLayerIsInCombat = false
---local DispellableDebuffCache = {}
-
----------------------------------------------------------------------------------------------------
--- Cached configuration settings
----------------------------------------------------------------------------------------------------
-local HideOmniCC, SetNoCooldownCount, ShowDuration, SortFunction
-local AuraHighlightEnabled, AuraHighlightStart, AuraHighlightStop, AuraHighlightStopPrevious, AuraHighlightOffset
-local AuraHighlightColor = { 0, 0, 0, 0 }
+local HideOmniCC, ShowDuration
 local EnabledForStyle = {}
-
----------------------------------------------------------------------------------------------------
--- OnUpdate code - updates the auras remaining uptime and stacks and hides them after they expired
----------------------------------------------------------------------------------------------------
-
-local function OnShowHookScript(widget_frame)
-  widget_frame.Buffs.TimeSinceLastUpdate = 0
-  widget_frame.Debuffs.TimeSinceLastUpdate = 0
-  widget_frame.CrowdControl.TimeSinceLastUpdate = 0
-end
-
----------------------------------------------------------------------------------------------------
--- Code for showing tooltips on auras
----------------------------------------------------------------------------------------------------
-
-local AuraTooltip = CreateFrame("GameTooltip", "ThreatPlatesAuraTooltip", UIParent, "GameTooltipTemplate")
-local AuraFrameOnEnter
-
-local function AuraFrameOnLeave(self)
-  AuraTooltip:Hide()
-end
-
--- SetUnitAuraByAuraInstanceID: WoW Midnight
--- SetUnitBuffByAuraInstanceID, SetUnitDebuffByAuraInstanceID: Dragonflight - Patch 10.0.0
--- Would show more information, but mainly about the spell, not the aura
--- AuraTooltip:SetSpellByID(self.AuraData.spellId)
-if AuraTooltip.SetUnitAuraByAuraInstanceID then
-  AuraFrameOnEnter = function(self)
-    AuraTooltip:SetOwner(self, "ANCHOR_LEFT")
-    AuraTooltip:SetUnitAuraByAuraInstanceID(self:GetParent():GetParent().unit.unitid, self.AuraData.auraInstanceID)
-  end
-elseif AuraTooltip.SetUnitBuffByAuraInstanceID and AuraTooltip.SetUnitDebuffByAuraInstanceID then
-  AuraFrameOnEnter = function(self)
-    AuraTooltip:SetOwner(self, "ANCHOR_LEFT")
-
-    -- I really think that SetUnit...ByAuraInstanceID does not the filter parameter, but still ...
-    if self.AuraData.effect == "HELPFUL" then
-      AuraTooltip:SetUnitBuffByAuraInstanceID(self:GetParent():GetParent().unit.unitid, self.AuraData.auraInstanceID, self.AuraData.effect)
-    else
-      AuraTooltip:SetUnitDebuffByAuraInstanceID(self:GetParent():GetParent().unit.unitid, self.AuraData.auraInstanceID, self.AuraData.effect)
-    end
-  end
-else
-  AuraFrameOnEnter = function(self)
-    AuraTooltip:SetOwner(self, "ANCHOR_LEFT")
-    AuraTooltip:SetUnitAura(self:GetParent():GetParent().unit.unitid, self.AuraData.auraInstanceID, self.AuraData.effect)
-  end
-end
-
----------------------------------------------------------------------------------------------------
--- Filtering and sorting functions
----------------------------------------------------------------------------------------------------
-
-local DEBUFF_DISPLAY_COLOR_INFO = {
-  [0] = DEBUFF_TYPE_NONE_COLOR,
-  [1] = DEBUFF_TYPE_MAGIC_COLOR,
-  [2] = DEBUFF_TYPE_CURSE_COLOR,
-  [3] = DEBUFF_TYPE_DISEASE_COLOR,
-  [4] = DEBUFF_TYPE_POISON_COLOR,
-  [9] = DEBUFF_TYPE_BLEED_COLOR, -- enrage
-  [11] = DEBUFF_TYPE_BLEED_COLOR,
+local AuraFilterSpellIDs = {
+  Buffs = { include = {}, exclude = {} },
+  Debuffs = { include = {}, exclude = {} },
+  CrowdControl = { include = {}, exclude = {} },
 }
 
-local DispelColorCurve = C_CurveUtil.CreateColorCurve()
+---------------------------------------------------------------------------------------------------
+-- Helpers
+---------------------------------------------------------------------------------------------------
 
-DispelColorCurve:SetType(Enum.LuaCurveType.Step)
-for i, c in pairs(DEBUFF_DISPLAY_COLOR_INFO) do
-  DispelColorCurve:AddPoint(i, c)
+local function CanRestyleButtons()
+  if InCombatLockdown() then
+    return false
+  end
+  if ShouldAurasBeSecret and ShouldAurasBeSecret() then
+    return false
+  end
+  return true
 end
 
-function Widget:GetColorForAura(aura, unitid)
-	local db = self.db
+local function GetSpellIDFromIdentifier(spell)
+  local id = tonumber(spell)
+  if id then
+    return id
+  end
+  if not spell or spell == "" then
+    return nil
+  end
 
-  -- if aura.dispelName and db.ShowAuraType then
-  if db.ShowAuraType and Addon.ExpansionIsAtLeastMidnight then
-    local color = GetAuraDispelTypeColor(aura.unitid, aura.auraInstanceID, DispelColorCurve)
-    if color then
-      return color
+  if C_Spell and C_Spell.GetSpellIDForSpellIdentifier then
+    local ok, result = pcall(C_Spell.GetSpellIDForSpellIdentifier, spell)
+    if ok and result then
+      return result
     end
   end
 
-  if aura.effect == "HARMFUL" then  
-    return db.DefaultDebuffColor
+  if C_Spell and C_Spell.GetSpellInfo then
+    local ok, info = pcall(C_Spell.GetSpellInfo, spell)
+    if ok and type(info) == "table" and info.spellID then
+      return info.spellID
+    end
+  end
+end
+
+local function JoinFilter(...)
+  local parts = {}
+  for i = 1, select("#", ...) do
+    local part = select(i, ...)
+    if part and part ~= "" then
+      tinsert(parts, part)
+    end
+  end
+  return table.concat(parts, "|")
+end
+
+local function CopySpellSet(src)
+  if not src or not next(src) then
+    return nil
+  end
+  local copy = {}
+  for spell_id in pairs(src) do
+    copy[spell_id] = true
+  end
+  return copy
+end
+
+local function IsWhitelist(filter_mode)
+  return filter_mode == "whitelist" or filter_mode == "Allow"
+end
+
+local function IsBlacklist(filter_mode)
+  return filter_mode == "blacklist" or filter_mode == "Block"
+end
+
+---------------------------------------------------------------------------------------------------
+-- Aura button visuals
+---------------------------------------------------------------------------------------------------
+
+local function StyleAuraButton(button, aura_type)
+  local aura_grid = Widget[aura_type]
+  if not aura_grid then
+    return
+  end
+
+  local db_icon = aura_grid.db
+  local db_widget = aura_grid.db_widget or Widget.db
+  local width = aura_grid.IconWidth or (db_icon and db_icon.IconWidth) or 16
+  local height = aura_grid.IconHeight or (db_icon and db_icon.IconHeight) or 16
+
+  button:SetSize(width, height)
+
+  if button.Icon then
+    button.Icon:SetTexCoord(0.10, 1 - 0.07, 0.12, 1 - 0.12)
+  end
+
+  if button.Cooldown then
+    local show_swipe = db_widget and db_widget.ShowCooldownSpiral
+    button.Cooldown:SetDrawSwipe(show_swipe and true or false)
+    button.Cooldown:SetDrawEdge(show_swipe and true or false)
+    button.Cooldown.noCooldownCount = HideOmniCC
+  end
+
+  if button.TimeLeft then
+    if ShowDuration then
+      button.TimeLeft:Show()
+      if db_icon and db_icon.Duration then
+        FontUpdateText(button, button.TimeLeft, db_icon.Duration)
+      end
+    else
+      button.TimeLeft:Hide()
+    end
+  end
+
+  if button.Stacks then
+    if db_widget and db_widget.ShowStackCount then
+      button.Stacks:Show()
+      if db_icon and db_icon.StackCount then
+        FontUpdateText(button, button.Stacks, db_icon.StackCount)
+      end
+    else
+      button.Stacks:Hide()
+    end
+  end
+
+  if button.Border then
+    local show_border = not db_icon or db_icon.ShowBorder
+    button.Border:SetShown(show_border and true or false)
+    if show_border and db_widget then
+      local color
+      if aura_type == "Buffs" then
+        color = db_widget.DefaultBuffColor
+      else
+        color = db_widget.DefaultDebuffColor
+      end
+      if color then
+        button.Border:SetVertexColor(color.r or 0, color.g or 0, color.b or 0, color.a or 1)
+      end
+    end
+  end
+
+  local show_tooltips = db_widget and db_widget.ShowTooltips
+  if button.SetHideTooltipInCombat then
+    button:SetHideTooltipInCombat(not show_tooltips)
+  end
+  if CanRestyleButtons() and button.SetMouseMotionEnabled then
+    button:SetMouseMotionEnabled(show_tooltips and true or false)
+  end
+end
+
+local function InitAuraButton(button, aura_type)
+  local aura_grid = Widget[aura_type]
+  local width = aura_grid and aura_grid.IconWidth or 16
+  local height = aura_grid and aura_grid.IconHeight or 16
+  button:SetSize(width, height)
+
+  local icon = button:CreateTexture(nil, "ARTWORK")
+  icon:SetAllPoints(button)
+  icon:SetTexCoord(0.10, 1 - 0.07, 0.12, 1 - 0.12)
+  button.Icon = icon
+  button:SetIcon(icon)
+
+  local cooldown = CreateFrame("Cooldown", nil, button, "CooldownFrameTemplate")
+  cooldown:SetAllPoints(button)
+  cooldown:SetReverse(true)
+  cooldown:SetHideCountdownNumbers(true)
+  cooldown:SetDrawBling(false)
+  cooldown.noCooldownCount = HideOmniCC
+  button.Cooldown = cooldown
+  button:SetDurationCooldown(cooldown)
+
+  local overlay = CreateFrame("Frame", nil, button)
+  overlay:SetAllPoints(button)
+  overlay:SetFrameLevel(cooldown:GetFrameLevel() + 1)
+  button.Overlay = overlay
+
+  local border = overlay:CreateTexture(nil, "OVERLAY")
+  border:SetPoint("TOPLEFT", button, "TOPLEFT", -2, 2)
+  border:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT", 2, -2)
+  border:SetTexture(Widget.TEXTURE_BORDER)
+  button.Border = border
+
+  local show_helpful = aura_type == "Buffs"
+  if button.SetAuraBorder then
+    button:SetAuraBorder(border, {
+      showIcon = false,
+      showWhenHarmful = not show_helpful,
+      showWhenHelpful = show_helpful,
+      showWithoutDispelType = true,
+      style = DispelStyle and DispelStyle.PreserveAsset,
+    })
+  end
+
+  -- AuraContainer calls SetText immediately after initializeFrame. FontStrings must
+  -- inherit a font template (or SetFont) before SetApplicationCount / SetDurationText.
+  local stacks = overlay:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+  stacks:SetJustifyH("RIGHT")
+  stacks:SetPoint("BOTTOMRIGHT", button, "BOTTOMRIGHT", 1, 0)
+  button.Stacks = stacks
+  if button.SetApplicationCount then
+    button:SetApplicationCount(stacks)
+  end
+
+  local time_left = overlay:CreateFontString(nil, "OVERLAY", "NumberFontNormalSmall")
+  time_left:SetJustifyH("RIGHT")
+  time_left:SetPoint("TOPRIGHT", button, "TOPRIGHT", 1, 0)
+  button.TimeLeft = time_left
+  if button.SetDurationText then
+    button:SetDurationText(time_left)
+  end
+
+  button.AuraType = aura_type
+  StyleAuraButton(button, aura_type)
+
+  local container = button:GetParent()
+  if container then
+    container.AuraButtons = container.AuraButtons or {}
+    tinsert(container.AuraButtons, button)
+  end
+end
+
+---------------------------------------------------------------------------------------------------
+-- Filter construction
+---------------------------------------------------------------------------------------------------
+
+local function CandidateFilters(include, exclude)
+  local filters
+  if include and next(include) then
+    filters = filters or {}
+    filters.includeSpellIDs = CopySpellSet(include)
+  end
+  if exclude and next(exclude) then
+    filters = filters or {}
+    filters.excludeSpellIDs = CopySpellSet(exclude)
+  end
+  return filters
+end
+
+local function AddGroup(groups, key, filter, include, exclude, max_count)
+  if not filter or max_count == 0 then
+    return
+  end
+  tinsert(groups, {
+    key = key,
+    filter = filter,
+    candidates = CandidateFilters(include, exclude),
+    maxCount = max_count,
+  })
+end
+
+local function BuildGroupsForType(aura_type, unit, exclude_cc)
+  local db = Widget.db[aura_type]
+  local aura_grid = Widget[aura_type]
+  local groups = {}
+  local max_count = aura_grid and aura_grid.MaxAuras or 10
+  local is_friendly = unit.reaction == "FRIENDLY"
+  local is_npc = unit.type == "NPC"
+  local spell_ids = AuraFilterSpellIDs[aura_type]
+  local include = spell_ids and spell_ids.include
+  local exclude = spell_ids and spell_ids.exclude
+  local filter_mode = db.FilterMode
+  local cc_neg = (aura_type == "Debuffs" and exclude_cc) and "!CROWD_CONTROL" or nil
+
+  local enabled
+  if is_friendly then
+    enabled = db.ShowFriendly
   else
-    return db.DefaultBuffColor
-	end
+    enabled = db.ShowEnemy
+  end
+  if not enabled then
+    return groups
+  end
+
+  if IsWhitelist(filter_mode) then
+    local base
+    if aura_type == "Buffs" then
+      base = JoinFilter("HELPFUL", "INCLUDE_NAME_PLATE_ONLY")
+    elseif aura_type == "CrowdControl" then
+      base = JoinFilter("HARMFUL", "CROWD_CONTROL", "INCLUDE_NAME_PLATE_ONLY")
+    else
+      base = JoinFilter("HARMFUL", "INCLUDE_NAME_PLATE_ONLY", cc_neg)
+    end
+    AddGroup(groups, "Whitelist", base, include, nil, max_count)
+    return groups
+  end
+
+  local blacklist = IsBlacklist(filter_mode) and exclude or nil
+
+  if aura_type == "CrowdControl" then
+    AddGroup(groups, "CrowdControl", JoinFilter("HARMFUL", "CROWD_CONTROL", "INCLUDE_NAME_PLATE_ONLY"), nil, blacklist, max_count)
+    return groups
+  end
+
+  if aura_type == "Buffs" then
+    local show_all = (is_friendly and db.ShowAllFriendly) or (not is_friendly and db.ShowAllEnemy)
+    local show_npcs = (is_friendly and db.ShowOnFriendlyNPCs) or (not is_friendly and db.ShowOnEnemyNPCs)
+    local show_dispellable = not is_friendly and db.ShowDispellable
+    local show_mine = db.ShowOnlyMine
+
+    if show_all or (show_npcs and is_npc) then
+      AddGroup(groups, "Main", JoinFilter("HELPFUL", "INCLUDE_NAME_PLATE_ONLY"), nil, blacklist, max_count)
+    else
+      if show_mine then
+        AddGroup(groups, "Mine", JoinFilter("HELPFUL", "PLAYER", "INCLUDE_NAME_PLATE_ONLY"), nil, blacklist, max_count)
+      end
+      if show_dispellable then
+        AddGroup(groups, "Dispellable", JoinFilter("HELPFUL", "RAID_PLAYER_DISPELLABLE", "INCLUDE_NAME_PLATE_ONLY", show_mine and "!PLAYER" or nil), nil, blacklist, max_count)
+      end
+      -- Friendly buffs with no matching toggle still show nothing, matching previous behaviour.
+      if not show_mine and not show_dispellable and not show_all and not (show_npcs and is_npc) then
+        -- Keep empty groups so the container stays disabled.
+      end
+    end
+    return groups
+  end
+
+  -- Debuffs
+  local show_all = (is_friendly and db.ShowAllFriendly) or (not is_friendly and db.ShowAllEnemy)
+  local show_mine = not is_friendly and db.ShowOnlyMine
+  local show_blizzard = not is_friendly and db.ShowBlizzardForEnemy
+  local show_dispellable = is_friendly and db.ShowDispellable
+
+  if show_all then
+    AddGroup(groups, "Main", JoinFilter("HARMFUL", "INCLUDE_NAME_PLATE_ONLY", cc_neg), nil, blacklist, max_count)
+  else
+    if show_mine then
+      AddGroup(groups, "Mine", JoinFilter("HARMFUL", "PLAYER", "INCLUDE_NAME_PLATE_ONLY", cc_neg), nil, blacklist, max_count)
+    end
+    if show_blizzard then
+      AddGroup(groups, "Important", JoinFilter("HARMFUL", "IMPORTANT", "INCLUDE_NAME_PLATE_ONLY", show_mine and "!PLAYER" or nil, cc_neg), nil, blacklist, max_count)
+    end
+    if show_dispellable then
+      AddGroup(groups, "Dispellable", JoinFilter("HARMFUL", "RAID_PLAYER_DISPELLABLE", "INCLUDE_NAME_PLATE_ONLY", cc_neg), nil, blacklist, max_count)
+    end
+  end
+
+  return groups
 end
 
-local function FilterNone(show_aura, spellfound, is_mine, show_only_mine)
-  return show_aura
+---------------------------------------------------------------------------------------------------
+-- Container layout / groups
+---------------------------------------------------------------------------------------------------
+
+local function GetFlowOptions(aura_type)
+  local db = Widget.db[aura_type]
+  local aura_grid = Widget[aura_type]
+  local grow_right = db.AlignmentH ~= "RIGHT"
+  local grow_up = db.AlignmentV ~= "TOP"
+
+  local anchor
+  if grow_right then
+    anchor = grow_up and "BOTTOMLEFT" or "TOPLEFT"
+  else
+    anchor = grow_up and "BOTTOMRIGHT" or "TOPRIGHT"
+  end
+
+  local horizontal = (FlowDirection and (grow_right and FlowDirection.Right or FlowDirection.Left)) or (grow_right and 1 or 2)
+  local vertical = (FlowDirection and (grow_up and FlowDirection.Up or FlowDirection.Down)) or (grow_up and 3 or 4)
+
+  local width = aura_grid.IconWidth or 16
+  local height = aura_grid.IconHeight or 16
+  local spacing_x = aura_grid.ColumnSpacing or 5
+  local spacing_y = aura_grid.RowSpacing or 8
+  local columns = aura_grid.Columns or 5
+  local line_size = columns * width + max(columns - 1, 0) * spacing_x
+
+  return {
+    anchor = anchor,
+    horizontal = horizontal,
+    vertical = vertical,
+    layout = {
+      elementSpacing = spacing_x,
+      lineSpacing = spacing_y,
+      elementWidth = width,
+      elementHeight = height,
+    },
+    lineSize = line_size,
+  }
 end
 
-local function FilterAllowlist(show_aura, spellfound, is_mine, show_only_mine)
-  if spellfound == "All" then
-    return show_aura
-  elseif spellfound == true then
-    return (show_only_mine == nil and show_aura) or (show_aura and ((show_only_mine and is_mine) or show_only_mine == false))
-  elseif spellfound == "My" then
-    return show_aura and is_mine
+local function GetSortOptions()
+  local method = SortMethod and SortMethod.Default
+  local direction = SortDirection and SortDirection.Normal
+  local order = Widget.db.SortOrder
+  if SortMethod then
+    if order == "TimeLeft" or order == "Duration" or order == "Creation" then
+      method = SortMethod.Expiration or SortMethod.ExpirationOnly or method
+    end
+  end
+  if Widget.db.SortReverse and SortDirection then
+    direction = SortDirection.Reverse
+  end
+  return method, direction
+end
+
+local function EnsureGroups(container, aura_type)
+  if not HAS_AURA_CONTAINER then
+    return
+  end
+
+  container.Groups = container.Groups or {}
+  local flow = GetFlowOptions(aura_type)
+  local sort_method, sort_direction = GetSortOptions()
+
+  for index, group_key in ipairs(GROUP_KEYS) do
+    if not container.Groups[group_key] then
+      local layout = {}
+      for k, v in pairs(flow.layout) do
+        layout[k] = v
+      end
+      layout.layoutIndex = index
+
+      container:AddAuraGroup(group_key, "", {
+        maxFrameCount = 0,
+        sortMethod = sort_method,
+        sortDirection = sort_direction,
+        initializeFrame = function(button)
+          InitAuraButton(button, aura_type)
+        end,
+        layout = layout,
+      })
+      container.Groups[group_key] = true
+    end
+  end
+end
+
+local function DisableAllGroups(container)
+  if not container.Groups then
+    return
+  end
+  for group_key in pairs(container.Groups) do
+    container:SetAuraGroupFilterString(group_key, "")
+    container:SetAuraGroupMaxFrameCount(group_key, 0)
+  end
+end
+
+local function ApplyGroups(container, filter_type, unit, exclude_cc)
+  if not HAS_AURA_CONTAINER then
+    return
+  end
+
+  local layout_type = container.AuraType or filter_type
+  EnsureGroups(container, layout_type)
+  DisableAllGroups(container)
+
+  local flow = GetFlowOptions(layout_type)
+  container:SetFlowLayoutAnchorPoint(flow.anchor)
+  container:SetFlowLayoutGrowthDirection(flow.horizontal, flow.vertical)
+  container:SetFlowLayoutMaximumLineSize(flow.lineSize)
+
+  local sort_method, sort_direction = GetSortOptions()
+  local groups = BuildGroupsForType(filter_type, unit, exclude_cc)
+  local enabled = #groups > 0
+
+  for index, group in ipairs(groups) do
+    if container.Groups[group.key] then
+      local layout = {}
+      for k, v in pairs(flow.layout) do
+        layout[k] = v
+      end
+      layout.layoutIndex = index
+
+      container:SetAuraGroupFilterString(group.key, group.filter)
+      container:SetAuraGroupCandidateFilters(group.key, group.candidates or {})
+      container:SetAuraGroupMaxFrameCount(group.key, group.maxCount)
+      container:SetAuraGroupSortMethod(group.key, sort_method, sort_direction)
+      container:SetAuraGroupLayout(group.key, layout)
+    end
+  end
+
+  container:SetSize(1, 1)
+  return enabled
+end
+
+local function CreateAuraContainer(parent, aura_type)
+  if not HAS_AURA_CONTAINER then
+    local frame = CreateFrame("Frame", nil, parent)
+    frame:Hide()
+    frame.AuraType = aura_type
+    frame.AuraButtons = {}
+    return frame
+  end
+
+  local container = CreateFrame("AuraContainer", nil, parent, "CustomAuraContainerTemplate")
+  container:SetEnabled(false)
+  container:Hide()
+  container:SetSize(1, 1)
+  container.AuraType = aura_type
+  container.AuraButtons = {}
+  EnsureGroups(container, aura_type)
+  return container
+end
+
+local function RestyleContainerButtons(container, aura_type)
+  if not CanRestyleButtons() then
+    return
+  end
+  local buttons = container.AuraButtons
+  if not buttons then
+    return
+  end
+  for i = 1, #buttons do
+    StyleAuraButton(buttons[i], aura_type)
+  end
+end
+
+---------------------------------------------------------------------------------------------------
+-- Positioning
+---------------------------------------------------------------------------------------------------
+
+function Widget:UpdatePositionAuraGrid(widget_frame, aura_type, unit_style)
+  local db = self.db[aura_type]
+  local container = widget_frame[aura_type]
+  local anchor_to_db = db.AnchorTo
+  local anchor_to = (anchor_to_db == "Healthbar" and widget_frame) or widget_frame[anchor_to_db]
+
+  AnchorFrameTo(db[MODE_FOR_STYLE[unit_style]], container, anchor_to)
+end
+
+---------------------------------------------------------------------------------------------------
+-- Update
+---------------------------------------------------------------------------------------------------
+
+local function ShouldHideForUnit(widget_frame, unit)
+  local unit_is_target = UnitIsUnitTP("target", unit.unitid)
+  if Widget.db.ShowTargetOnly then
+    if unit_is_target then
+      Widget.CurrentTarget = widget_frame
+    else
+      return true
+    end
+  end
+
+  if not EnabledForStyle[unit.style] then
+    return true
   end
 
   return false
 end
 
-local function FilterBlocklist(show_aura, spellfound, is_mine, show_only_mine)
-  -- blacklist all auras, i.e., default is show all auras (no matter who casted it)
-  --   spellfound = true or All - blacklist this aura (from all casters)
-  --   spellfound = My          - blacklist only my aura
-  --   spellfound = nil         - show aura (spell not found in blacklist)
-  --   spellfound = Not         - show aura (found entry not relevant, ignore it)
-
-  if spellfound == "All" or spellfound == true then
-    return false
-  elseif spellfound == "My" then
-    return not is_mine
-  elseif spellfound == "Not" then
-    return true
-  end
-
-  return show_aura
-end
-
-Widget.FILTER_FUNCTIONS = {
-  all = FilterNone,
-  blacklist = FilterBlocklist,
-  whitelist = FilterAllowlist,
-  None = FilterNone,
-  Block = FilterBlocklist,
-  Allow = FilterAllowlist,
-}
-
-function Widget:FilterFriendlyDebuffsBySpell(db, aura, AuraFilterFunction, unit)    
-  local show_aura = 
-    db.ShowAllFriendly
-    --(db.ShowBlizzardForFriendly and (aura.nameplateShowAll or (aura.nameplateShowPersonal and aura.CastByPlayer))) or
-    or (db.ShowDispellable and aura.IsDispellable)
-    --(db.ShowBoss and aura.isBossAura) or
-    --(aura.dispelName and db.FilterByType[self.AURA_TYPE[aura.dispelName]])
-
-  return show_aura
-end
-
-function Widget:FilterEnemyDebuffsBySpell(db, aura, AuraFilterFunction, unit)
-  local show_aura = 
-    db.ShowAllEnemy 
-    or (db.ShowOnlyMine and aura.CastByPlayer) 
-    or (db.ShowBlizzardForEnemy and (aura.IsImportant or aura.CastByPlayer))
-
-  return show_aura
-end
-
-function Widget:FilterFriendlyCrowdControlBySpell(db, aura, AuraFilterFunction, unit)
-  local show_aura = 
-    db.ShowAllFriendly
-    --(db.ShowBlizzardForFriendly and (aura.nameplateShowAll or (aura.nameplateShowPersonal and aura.CastByPlayer))) or
-    or (db.ShowDispellable and aura.IsDispellable)
-    --(db.ShowBoss and aura.isBossAura)
-
-  return show_aura
-end
-
-function Widget:FilterEnemyCrowdControlBySpell(db, aura, AuraFilterFunction, unit)
-  local show_aura = 
-    db.ShowAllEnemy 
-    --or (db.ShowBlizzardForEnemy and (aura.nameplateShowAll or (aura.nameplateShowPersonal and aura.CastByPlayer)))
-
-  return show_aura
-end  
-
-function Widget:FilterFriendlyBuffsBySpell(db, aura, AuraFilterFunction, unit)
-  local show_aura = 
-    db.ShowAllFriendly 
-    or (db.ShowOnFriendlyNPCs and unit.type == "NPC") 
-    or (db.ShowOnlyMine and aura.CastByPlayer)
-    -- or (db.ShowPlayerCanApply and aura.canApplyAura)
-
-  return show_aura
-end
-
-function Widget:FilterEnemyBuffsBySpell(db, aura, AuraFilterFunction, unit)
-  local show_aura = 
-    db.ShowAllEnemy 
-    or (db.ShowOnEnemyNPCs and unit.type == "NPC")
-    or (db.ShowDispellable and aura.IsDispellable)
-    -- (aura.dispelName == "Magic" and db.ShowMagic)
-
-    -- if aura.duration and db.HideUnlimitedDuration then
-
-    -- -- Checking unlimited auras after filter function results in the filter list not being able to overwrite
-    -- -- the "Show Unlimited Buffs" settings
-    -- if show_aura and (aura.duration <= 0) then
-    --   show_aura =  db.ShowUnlimitedAlways or
-    --     (db.ShowUnlimitedInCombat and unit.InCombat) or
-    --     (db.ShowUnlimitedInInstances and Addon.IsInInstance) or
-    --     (db.ShowUnlimitedOnBosses and unit.IsBossOrRare)
-    --   unit.HasUnlimitedAuras = true
-    -- end
-
-  return show_aura
-end
-
----------------------------------------------------------------------------------------------------
--- Aura Sorting
----------------------------------------------------------------------------------------------------
-
-local PRIORITY_FUNCTIONS = {
-  None = function(aura) return 0 end,
-  AtoZ = function(aura) return aura.name end,
-  TimeLeft = function(aura) return aura.expirationTime - GetTime() end,
-  Duration = function(aura) return aura.duration end,
-  Creation = function(aura) return aura.expirationTime - aura.duration end,
-}
-
-local function AuraSortFunctionAtoZ(a, b)
-  return a.priority < b.priority
-end
-
-local function AuraSortFunctionZtoA(a, b)
-  return a.priority > b.priority
-end
-
--- For auras without duration duration and expirationTime are 0, so sorting by TimeLeft, Duration, and Creation
--- does not work in that case. We will just sort by name for these auras
-local function AuraSortFunctionNumAscending(a, b)
-  if a.duration == 0 then
-    if b.duration == 0 then
-      return a.name < b.name
-    else
-      return false
-    end
-  elseif b.duration == 0 then
-    if a.duration == 0 then
-      return a.name < b.name
-    else
-      return true
-    end
-  else
-    return a.priority < b.priority
-  end
-end
-
-local function AuraSortFunctionNumDescending(a, b)
-  if a.duration == 0 then
-    if b.duration == 0 then
-      return a.name > b.name
-    else
-      return true
-    end
-  elseif b.duration == 0 then
-    if a.duration == 0 then
-      return a.name > b.name
-    else
-      return false
-    end
-  else
-    return a.priority > b.priority
-  end
-end
-
-local SORT_FUNCTIONS = {
-  None = nil,
-  AtoZ = {
-    Default = AuraSortFunctionAtoZ,
-    Reverse = AuraSortFunctionZtoA,
-  },
-  TimeLeft = {
-    Default = AuraSortFunctionNumAscending,
-    Reverse = AuraSortFunctionNumDescending,
-  },
-  Duration = {
-    Default = AuraSortFunctionNumAscending,
-    Reverse = AuraSortFunctionNumDescending,
-  },
-  Creation = {
-    Default = AuraSortFunctionNumAscending,
-    Reverse = AuraSortFunctionNumDescending,
-  },
-}
-
-local function SortAurasByPriority(unit_auras)
-  if #unit_auras >= 0 and SortFunction then
-    sort(unit_auras, SortFunction)
-  end
-end
-
----------------------------------------------------------------------------------------------------
--- Auras Module / Handler 
----------------------------------------------------------------------------------------------------
-
--- UnitAuraSlots: BfA - Patch 8.2.5 (2019-09-24): Added.
--- C_UnitAuras.GetAuraSlots: DF - Patch 10.2.5 (2024-01-16): Deprecated. Replaced by C_UnitAuras.GetAuraSlots.
-local function ProcessAllUnitAuras(unitid, effect)
-  -- local aura_max_display = (effect == "HARMFUL" and DEBUFF_MAX_DISPLAY) or BUFF_MAX_DISPLAY
-
-  -- -- AuraUtil.ForEachAura(unitid, effect, BUFF_MAX_DISPLAY, function(unit_aura_info)
-  -- --   unit_aura_info.duration = unit_aura_info.duration or 0
-  -- --   unit_auras[#unit_auras + 1] = unit_aura_info
-  -- --   -- Addon.Logging.Debug("Aura:", aura.name, "=> ID:", aura.spellId)
-  -- -- end, true)
-
-  -- -- AuraUtil.ForEachAura:
-  -- local continuation_token
-  -- repeat
-  --   -- continuationToken is the first return value of UnitAuraSlots
-  --   local slots = { GetAuraSlots(unitid, effect, aura_max_display, continuation_token) }
-  --   continuation_token = slots[1]
-
-  --   for i = 2, #slots do
-  --     local unit_aura_info = GetAuraDataBySlot(unitid, slots[i])  
-  --     -- Without this check, there will be a Lua error when a priest mindcontrolls another player as 
-  --     -- unit_aura_info is nil here in this case
-  --     if type(unit_aura_info) ~= nil then
-  --       --unit_aura_info.duration = unit_aura_info.duration or 0
-  --       unit_auras[#unit_auras + 1] = unit_aura_info
-
-  --       print(unit_aura_info.name, "=>", not C_UnitAuras.IsAuraFilteredOutByInstanceID(unitid, unit_aura_info.auraInstanceID, 'HARMFUL|PLAYER'))
-  --     end
-  --   end
-  -- until continuation_token == nil
-
-  -- return unit_auras
-
-  local unit_auras = {}
-  local function HandleAura(aura)
-    unit_auras[#unit_auras + 1] = aura
-    
-    aura.effect = effect
-    aura.CastByPlayer = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|PLAYER") -- aura.isFromPlayerOrPlayerPet, aura.nameplateShowPersonal
-    --aura.IsRaid = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|RAID") -- aura.isRaid
-    -- CANCELABLE, NOT_CANCELABLE
-    --aura.fd = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|INCLUDE_NAME_PLATE_ONLY") -- aura.isNameplateOnly
-    aura.IsExternalDefensive = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|EXTERNAL_DEFENSIVE")
-    aura.CrowdControl = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|CROWD_CONTROL")    
-    aura.IsRaidInCombat = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|RAID_IN_COMBAT")
-    aura.IsDispellable = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|RAID_PLAYER_DISPELLABLE")
-    aura.IsBigDefensive = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|BIG_DEFENSIVE")
-    aura.IsImportant = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|IMPORTANT")
-    
-    -- if aura.CastByPlayer or aura.IsRaid or aura.IsExternalDefensive or aura.CrowdControl or aura.IsRaidInCombat or
-    --   aura.IsDispellable or aura.IsBigDefensive or aura.IsImportant then
-    --   print("Aura:", aura.name, "=>", 
-    --     aura.CastByPlayer and "PLAYER" or "", 
-    --     aura.IsRaid and "RAID" or "", 
-    --     --aura.IsNameplateOnly and "NAME_PLATE_ONLY" or "", 
-    --     aura.IsExternalDefensive and "EXTERNAL_DEFENSIVE" or "", 
-    --     aura.CrowdControl and "CROWD_CONTROL" or "", 
-    --     aura.IsRaidInCombat and "RAID_IN_COMBAT" or "", 
-    --     aura.IsDispellable and "RAID_PLAYER_DISPELLABLE" or "", 
-    --     aura.IsBigDefensive and "BIG_DEFENSIVE" or "", 
-    --     aura.IsImportant and "IMPORTANT" or "")
-
-    --     print("Filter:", aura.isNameplateOnly)
-    --     -- Secret values: 
-    --     -- aura.nameplateShowAll, aura.nameplateShowPersonal
-    -- end
-  end
-
-  AuraUtil.ForEachAura(unitid, effect, nil, HandleAura, true)
-
-  return unit_auras
-end
-
-local function IgnoreAuraUpdateForUnit(widget_frame, unit)
-  -- ! "Target Only" only supports the direct target, not action targets
-  local unit_is_target = UnitIsUnitTP("target", unit.unitid)
-  if Widget.db.ShowTargetOnly then
-    if unit_is_target then
-      Widget.CurrentTarget = widget_frame
-    elseif not Addon.ActiveAuraTriggers then
-      -- Continue with aura scanning for non-target units if there are aura triggers that might change the nameplates style
-      widget_frame:Hide()
-      return true
-    end
+function Widget:UpdateAuras(widget_frame, unit)
+  if not widget_frame or not unit or not unit.unitid then
+    return
   end
 
   AuraTriggerInitialize(unit)
 
-  widget_frame.HideAuras = not EnabledForStyle[unit.style] or (Widget.db.ShowTargetOnly and not unit_is_target)  
-end
-
-local function AuraGridUpdateForUnitNotNecessary(widget_frame, unit)
-  AuraTriggerUpdateStyle(unit)
-
-  if widget_frame.HideAuras then
+  if ShouldHideForUnit(widget_frame, unit) then
+    if widget_frame.Buffs.SetEnabled then widget_frame.Buffs:SetEnabled(false) end
+    if widget_frame.Debuffs.SetEnabled then widget_frame.Debuffs:SetEnabled(false) end
+    if widget_frame.CrowdControl.SetEnabled then widget_frame.CrowdControl:SetEnabled(false) end
     widget_frame:Hide()
-    return true
-  end
-end
-
-local AuraGridUpdate = {
-  Buffs = false,
-  Debuffs = false,
-  CrowdControl = false,
-  --   BuffsAuraFrames = {},
-  --   DebuffsAuraFrames = {},
-  --   CrowdControlAuraFrames = {},
-  AuraFrames  ={}
-}
-
-local function FlagAuraGridForUpdate(aura_grid_update, is_crowdcontrol_aura, is_harmfull)
-  if is_crowdcontrol_aura then -- is_harmfull is true in this case
-    aura_grid_update.CrowdControl = true
-  elseif is_harmfull then
-    aura_grid_update.Debuffs = true
-  else
-    aura_grid_update.Buffs = true
-  end
-end
-
-function Widget:UNIT_AURA(unitid, update_info)
-  local widget_frame = self:GetWidgetFrameForUnit(unitid)
-  if widget_frame then 
-    widget_frame.Widget:UpdateAuras(widget_frame, widget_frame.unit)
-  end
-end
-
-function Widget:UpdateUnitAuras(aura_grid_frame, unit, enabled_auras, enabled_cc, SpellFilter, SpellFilterCC, effect, filter_mode)
-  local aura_grid = aura_grid_frame.AuraGrid
-
-  -- If auras are disabled, hide the grid and return an empty list
-  if not enabled_auras then
-    aura_grid_frame.ActiveAuras = 0
-    aura_grid_frame:Hide()
-    aura_grid:HideNonActiveAuras(aura_grid_frame)
+    AuraTriggerUpdateStyle(unit)
     return
   end
 
-  -- Show the aura grid – it may have been hidden when the nameplate was used for a unit
-  -- type where this aura category was disabled.
-  aura_grid_frame:Show()
-
   local db = self.db
+  local is_friendly = unit.reaction == "FRIENDLY"
+  local enabled_cc = is_friendly and db.CrowdControl.ShowFriendly or db.CrowdControl.ShowEnemy
 
-  aura_grid_frame.Filter = effect -- used for showing the correct tooltip
-  local widget_frame = aura_grid_frame:GetParent()
-  unit.HasUnlimitedAuras = false
-  local unitid = unit.unitid
-
-  local db_auras = (effect == "HARMFUL" and db.Debuffs) or db.Buffs
-  local AuraFilterFunction = self.FILTER_FUNCTIONS[filter_mode]
-  local AuraFilterFunctionCC = self.FILTER_FUNCTIONS[db.CrowdControl.FilterMode]
-
-  local unit_auras_to_show = {}
-
-  -- Can do this here as aura tiggers do not work in Midnight right now
-  if widget_frame.HideAuras then return end
-
-  local unit_auras = ProcessAllUnitAuras(unit.unitid, effect)
-  for i = 1, #unit_auras do
-    local aura = unit_auras[i]
-    local show_aura
-
-    --UnitStyle_AuraTrigger_CheckIfActive(unit, aura.spellId, aura.name, aura.CastByPlayer)
-    if aura.CrowdControl then
-      show_aura = SpellFilterCC(self, db.CrowdControl, aura, AuraFilterFunctionCC, unit)
-
-      -- Show crowd control auras that are not shown in Blizard mode as normal debuffs
-      if not show_aura and enabled_auras then
-        aura.CrowdControl = false
-        show_aura = SpellFilter(self, db_auras, aura, AuraFilterFunction, unit)
-      end
-    elseif enabled_auras then
-      show_aura = SpellFilter(self, db_auras, aura, AuraFilterFunction, unit)
-    end
-
-    if show_aura then
-      aura.unitid = unitid
-      aura.color = self:GetColorForAura(aura)
-      --aura.priority = PRIORITY_FUNCTIONS[db.SortOrder](aura)
-
-      unit_auras_to_show[#unit_auras_to_show + 1] = aura
-    end
+  local buff_container = widget_frame.Buffs
+  local debuff_container = widget_frame.Debuffs
+  if db.SwitchAreaByReaction and is_friendly then
+    buff_container = widget_frame.Debuffs
+    debuff_container = widget_frame.Buffs
   end
 
-  -- Show auras
-  local aura_grid_cc = self.CrowdControl
-  local aura_grid_frame_cc = widget_frame.CrowdControl
-
-  -- Sort auras based on order criteria
---  SortAurasByPriority(unit_auras_to_show)
-
-  local aura_count = 0
-  local aura_count_cc = 0
-  for index = 1, #unit_auras_to_show do
-    local aura_frame
-    
-    local aura = unit_auras_to_show[index]
-    if aura.spellId and aura.expirationTime then
-      if aura.CrowdControl then
-        -- Don't show CCs beyond MaxAuras, sorting should be correct here
-        if aura_count_cc < aura_grid_cc.MaxAuras then
-          aura_count_cc = aura_count_cc + 1
-          aura_frame = aura_grid_cc:GetAuraFrame(aura_grid_frame_cc, aura_count_cc)
-        end
-      else
-        if aura_count < aura_grid.MaxAuras then
-          aura_count = aura_count + 1
-          aura_frame = aura_grid:GetAuraFrame(aura_grid_frame, aura_count)
-        end          
-      end
-
-      -- aura_frame is nil here when the max amount of auras is already shown
-      if aura_frame then
-        aura_frame.unitid = unitid
-        widget_frame.UnitAuras[aura.auraInstanceID] = aura_frame
-
-        aura_frame.AuraData = aura
-        -- Call function to display the aura
-        if aura.CrowdControl then
-          aura_grid_cc:UpdateAuraInformation(aura_frame)
-        else
-          aura_grid:UpdateAuraInformation(aura_frame)
-        end
-      end
-
-      -- Both aura areas (buffs/debuffs) and crowd control are filled up, no further processing necessary
-      if aura_count >= aura_grid.MaxAuras and aura_count_cc >= aura_grid_cc.MaxAuras then
-        break
-      end
-    end
+  local buffs_on = ApplyGroups(buff_container, "Buffs", unit, false)
+  local debuffs_on = ApplyGroups(debuff_container, "Debuffs", unit, enabled_cc)
+  local cc_on = enabled_cc and ApplyGroups(widget_frame.CrowdControl, "CrowdControl", unit, false) or false
+  if not enabled_cc then
+    DisableAllGroups(widget_frame.CrowdControl)
   end
 
-  -- Hide non-active aura slots
-  aura_grid_frame.ActiveAuras = aura_count
-  aura_grid:HideNonActiveAuras(aura_grid_frame, true)
-
-  if effect == "HARMFUL" then
-    aura_grid_frame_cc.ActiveAuras = aura_count_cc
-    -- If scanning debuffs, also hide non-active CC aura slots
-    aura_grid_cc:HideNonActiveAuras(aura_grid_frame_cc)
+  if buff_container.SetUnit then
+    buff_container:SetUnit(unit.unitid)
+    buff_container:SetEnabled(buffs_on and true or false)
   end
-end
-
-function Widget:UpdatePositionAuraGrid(widget_frame, aura_type, unit_style)
-  local db = self.db
-
-  local aura_grid = self[aura_type]
-  local aura_grid_frame = widget_frame[aura_type]
-  local auras_no = aura_grid_frame.ActiveAuras
-
-  -- if not aura_grid_frame.TestBackground then
-  --  aura_grid_frame.TestBackground = aura_grid_frame:CreateTexture(nil, "BACKGROUND")
-  --  aura_grid_frame.TestBackground:SetAllPoints(aura_grid_frame)
-  --  aura_grid_frame.TestBackground:SetTexture(Addon.LibSharedMedia:Fetch('statusbar', Addon.db.profile.AuraWidget.BackgroundTexture))
-  --  aura_grid_frame.TestBackground:SetVertexColor(0,0,0,0.5)
-  -- end
-
-  local db_aura_grid = db[aura_type]
-  local anchor_to_db = db_aura_grid.AnchorTo
-  local anchor_to = (anchor_to_db == "Healthbar" and aura_grid_frame:GetParent()) or widget_frame[anchor_to_db]
-
-  AnchorFrameTo(db_aura_grid[MODE_FOR_STYLE[unit_style]], aura_grid_frame, anchor_to)
-  if aura_grid.IconMode and auras_no > 0 then
-    local x_offset = 0
-    if db_aura_grid.CenterAuras then
-      -- Re-anchor the first frame, if auras should be centered
-      x_offset = (auras_no < aura_grid.Columns) and aura_grid.CenterAurasPositions[auras_no] or 0
-    end
-    local align_layout = aura_grid.AlignLayout
-    local aura_one = aura_grid_frame.AuraFrames[1]
-    aura_one:ClearAllPoints()
-    aura_one:SetPoint(align_layout[3], aura_grid_frame, (aura_grid.AuraWidgetOffset + x_offset) * align_layout[5], (aura_grid.AuraWidgetOffset + aura_grid.RowSpacing) * align_layout[6])
+  if debuff_container.SetUnit then
+    debuff_container:SetUnit(unit.unitid)
+    debuff_container:SetEnabled(debuffs_on and true or false)
+  end
+  if widget_frame.CrowdControl.SetUnit then
+    widget_frame.CrowdControl:SetUnit(unit.unitid)
+    widget_frame.CrowdControl:SetEnabled(cc_on and true or false)
   end
 
-  aura_grid_frame:SetHeight(ceil(auras_no / aura_grid.Columns) * (aura_grid.AuraHeight + aura_grid.AuraWidgetOffset) +
-    aura_grid.RowSpacing + aura_grid.AuraWidgetOffset)
-end
+  self:UpdatePositionAuraGrid(widget_frame, "Buffs", unit.style)
+  self:UpdatePositionAuraGrid(widget_frame, "Debuffs", unit.style)
+  self:UpdatePositionAuraGrid(widget_frame, "CrowdControl", unit.style)
 
-function Widget:UpdateAurasGrids(widget_frame, unit)
-  local db = self.db
+  if buffs_on then buff_container:Show() else buff_container:Hide() end
+  if debuffs_on then debuff_container:Show() else debuff_container:Hide() end
+  if cc_on then widget_frame.CrowdControl:Show() else widget_frame.CrowdControl:Hide() end
 
-  widget_frame.UnitAuras = {}
-
-  local unitid = unit.unitid
-  widget_frame.Buffs.unitid = unitid
-  widget_frame.Debuffs.unitid = unitid
-  widget_frame.CrowdControl.unitid = unitid
-
-  local enabled_cc
-  if unit.reaction == "FRIENDLY"  then -- friendly or better
-    enabled_cc = db.CrowdControl.ShowFriendly
-    
-    local buff_aura_grid = (db.SwitchAreaByReaction and widget_frame.Debuffs) or widget_frame.Buffs
-    local debuff_aura_grid = (db.SwitchAreaByReaction and widget_frame.Buffs) or widget_frame.Debuffs        
-    
-    self:UpdateUnitAuras(buff_aura_grid, unit, db.Buffs.ShowFriendly, false, self.FilterFriendlyBuffsBySpell, self.FilterFriendlyCrowdControlBySpell, "HELPFUL", db.Buffs.FilterMode)
-    self:UpdateUnitAuras(debuff_aura_grid, unit, db.Debuffs.ShowFriendly, enabled_cc, self.FilterFriendlyDebuffsBySpell, self.FilterFriendlyCrowdControlBySpell, "HARMFUL", db.Debuffs.FilterMode)
-  else
-    enabled_cc = db.CrowdControl.ShowEnemy
-    
-    self:UpdateUnitAuras(widget_frame.Buffs, unit, db.Buffs.ShowEnemy, false, self.FilterEnemyBuffsBySpell, self.FilterEnemyCrowdControlBySpell, "HELPFUL", db.Buffs.FilterMode)
-    self:UpdateUnitAuras(widget_frame.Debuffs, unit, db.Debuffs.ShowEnemy, enabled_cc, self.FilterEnemyDebuffsBySpell, self.FilterEnemyCrowdControlBySpell, "HARMFUL", db.Debuffs.FilterMode)
-  end
-
-  if AuraGridUpdateForUnitNotNecessary(widget_frame, unit) then return end
-
-  if widget_frame.Buffs.ActiveAuras > 0 or widget_frame.Debuffs.ActiveAuras > 0 or widget_frame.CrowdControl.ActiveAuras > 0 then
-    self:UpdatePositionAuraGrid(widget_frame, "Buffs", unit.style)
-    self:UpdatePositionAuraGrid(widget_frame, "Debuffs", unit.style)
-
-    if enabled_cc then
-      self:UpdatePositionAuraGrid(widget_frame, "CrowdControl", unit.style)
-      widget_frame.CrowdControl:Show()
-    else
-      widget_frame.CrowdControl:Hide()
-    end
-
-    widget_frame:Show()
-  else
-    widget_frame:Hide()
-  end
-end
-
-function Widget:UpdateAuras(widget_frame, unit)
-  if not IgnoreAuraUpdateForUnit(widget_frame, unit) then 
-    self:UpdateAurasGrids(widget_frame, unit)
-  end
+  widget_frame:Show()
+  AuraTriggerUpdateStyle(unit)
 end
 
 ---------------------------------------------------------------------------------------------------
--- Creation and update functions
+-- Widget functions for creation and update
 ---------------------------------------------------------------------------------------------------
 
-local function OnUpdateAuraGridFrame(self, elapsed)
-  -- Update the number of seconds since the last update
-  self.TimeSinceLastUpdate = self.TimeSinceLastUpdate + elapsed
-
-  if self.TimeSinceLastUpdate >= self.AuraGrid.UpdateInterval then
-    self.TimeSinceLastUpdate = 0
-
-    local aura_frame
-    for i = 1, self.ActiveAuras do
-      aura_frame = self.AuraFrames[i]
-      self.AuraGrid:UpdateWidgetTime(aura_frame, aura_frame.AuraData.expirationTime, aura_frame.AuraData.duration)
-    end
-  end
-end
-
-function Widget:UpdateAuraGridLayout(widget_frame, aura_type)
-  local aura_grid = self[aura_type]
-  local aura_grid_frame = widget_frame[aura_type]
-  local aura_frame_list = aura_grid_frame.AuraFrames
-
-  local no_auras = #aura_frame_list
-
-  -- If the number of auras to show was decreased, remove any overflow aura frames
-  if no_auras > aura_grid.MaxAuras then
-    for i = no_auras, aura_grid.MaxAuras + 1, -1 do
-      aura_frame_list[i]:Hide()
-      aura_frame_list[i] = nil
-    end
-    no_auras = aura_grid.MaxAuras
-  end
-
-  -- When called from Create(), #aura_frame_list is 0, so nothing will be done here
-  -- When called from after a settings update, delete aura frames with wrong layout (icon/bar mode) and update all other aura frames
-  local icon_mode = aura_grid.IconMode
-  local aura_frame
-  for i = no_auras, 1, -1 do
-    aura_frame = aura_frame_list[i]
-    if icon_mode then
-      if aura_frame.Border then
-        aura_grid:UpdateAuraFramePosition(aura_frame_list, aura_grid_frame, aura_frame, i)
-        aura_grid:UpdateAuraFrame(aura_frame)
-      else
-        aura_frame:Hide()
-        aura_frame_list[i] = nil
-      end
-    else
-      if aura_frame.Statusbar then
-        aura_grid:UpdateAuraFramePosition(aura_frame_list, aura_grid_frame, aura_frame, i)
-        aura_grid:UpdateAuraFrame(aura_frame)
-      else
-        aura_frame:Hide()
-        aura_frame_list[i] = nil
-      end
-    end
-  end
-
-  aura_grid_frame:SetSize(aura_grid.AuraWidgetWidth, aura_grid.AuraWidgetHeight)
-
-  if ShowDuration or not aura_grid.IconMode then
-    aura_grid_frame:SetScript("OnUpdate", OnUpdateAuraGridFrame)
-  else
-    aura_grid_frame:SetScript("OnUpdate", nil)
-  end
-
-  aura_grid_frame:SetFrameLevel(widget_frame:GetFrameLevel())
-end
-
--- Initialize the aura grid layout, don't update auras themselves as not unitid know at this point
 function Widget:UpdateLayout(widget_frame)
   local frame_level
   if self.db.FrameOrder == "HEALTHBAR_AURAS" then
@@ -798,575 +665,30 @@ function Widget:UpdateLayout(widget_frame)
   end
   widget_frame:SetFrameLevel(frame_level)
 
-  -- ClearAllPoints here as otherwise Lua errors might occur if the old anchoring and the new anchoring
-  -- are cyclic temporarily
   widget_frame.Buffs:ClearAllPoints()
   widget_frame.Debuffs:ClearAllPoints()
   widget_frame.CrowdControl:ClearAllPoints()
-  
-  self:UpdateAuraGridLayout(widget_frame, "Buffs")
-  self:UpdateAuraGridLayout(widget_frame, "Debuffs")
-  self:UpdateAuraGridLayout(widget_frame, "CrowdControl")
+
+  widget_frame.Buffs:SetFrameLevel(frame_level)
+  widget_frame.Debuffs:SetFrameLevel(frame_level)
+  widget_frame.CrowdControl:SetFrameLevel(frame_level)
+
+  RestyleContainerButtons(widget_frame.Buffs, "Buffs")
+  RestyleContainerButtons(widget_frame.Debuffs, "Debuffs")
+  RestyleContainerButtons(widget_frame.CrowdControl, "CrowdControl")
 end
-
-function Widget:PLAYER_TARGET_CHANGED()
-  if not self.db.ShowTargetOnly then return end
-
-  if self.CurrentTarget then
-    self.CurrentTarget:Hide()
-    self.CurrentTarget = nil
-  end
-
-  local tp_frame = Addon:GetThreatPlateForTarget()
-  if tp_frame then
-    self.CurrentTarget = tp_frame.widgets.Auras
-
-    if self.CurrentTarget.Active then
-      self:UpdateAuras(self.CurrentTarget, tp_frame.unit)
-    end
-  end
-end
-
-
-function Widget:PLAYER_REGEN_ENABLED()
-  -- It seems that unitid here can be nil when using the healthstone while in combat
-  -- assert (unit.unitid ~= nil, "Auras: PLAYER_REGEN_ENABLED - unitid =", unit.unitid)
-
-  for unitid, tp_frame in Addon:GetActiveThreatPlates() do
-    local widget_frame = tp_frame.widgets.Auras
-    if widget_frame then 
-      local unit = tp_frame.unit
-      if unit.HasUnlimitedAuras then
-        self:UpdateAuras(widget_frame, unit)
-      end
-    end
-  end
-end
-
-Widget.PLAYER_REGEN_DISABLED = Widget.PLAYER_REGEN_ENABLED
-
----------------------------------------------------------------------------------------------------
--- Auras Area
----------------------------------------------------------------------------------------------------
-
-local function CreateAuraGrid(self, parent)
-  local aura_grid_frame = _G.CreateFrame("Frame", nil, parent)
-  aura_grid_frame.AuraFrames = {}
-  aura_grid_frame.ActiveAuras = 0
-  aura_grid_frame.AuraGrid = self
-
-  return aura_grid_frame
-end
-
-local function HideNonActiveAuras(self, aura_grid_frame, stop_highlight)
-  local aura_frames = aura_grid_frame.AuraFrames
-  for i = aura_grid_frame.ActiveAuras + 1, #aura_frames do
-    aura_frames[i]:Hide()
-    if stop_highlight then
-      AuraHighlightStop(aura_frames[i].Highlight)
-    end
-  end
-end
-
-local function UpdateAuraFramePosition(self, aura_frame_list, aura_grid_frame, aura_frame, no)
-  local align_layout = self.AlignLayout
-  aura_frame:ClearAllPoints()
-  if no == 1 then
-    aura_frame:SetPoint(align_layout[3], aura_grid_frame, self.AuraWidgetOffset * align_layout[5], (self.AuraWidgetOffset + self.RowSpacing) * align_layout[6])
-  elseif (no - 1) % self.Columns == 0 then
-    aura_frame:SetPoint(align_layout[3], aura_frame_list[no - self.Columns], align_layout[4], 0, self.RowSpacing * align_layout[6])
-  else
-    aura_frame:SetPoint(align_layout[1], aura_frame_list[no - 1], align_layout[2], self.ColumnSpacing * align_layout[5], 0)
-  end
-end
-
-local function GetAuraFrame(self, aura_grid_frame, no)
-  local aura_frame_list = aura_grid_frame.AuraFrames
-
-  local aura_frame = aura_frame_list[no]
-  if aura_frame == nil then
-    -- Should always be #aura_frame_list + 1
-    aura_frame = self:CreateAuraFrame(aura_grid_frame)
-
-    self:UpdateAuraFramePosition(aura_frame_list, aura_grid_frame, aura_frame, no)
-    self:UpdateAuraFrame(aura_frame)
-
-    aura_frame_list[no] = aura_frame
-  end
-
-  return aura_frame
-end
-
----------------------------------------------------------------------------------------------------
--- Functions for the aura grid with icons
----------------------------------------------------------------------------------------------------
-
-local function CreateAuraFrameIconMode(self, parent)
-  local frame = _G.CreateFrame("Frame", nil, parent)
-  frame:SetFrameLevel(parent:GetFrameLevel())
-
-  frame.Icon = frame:CreateTexture(nil, "ARTWORK", nil, -5)
-  frame.Border = _G.CreateFrame("Frame", nil, frame, BackdropTemplate)
-  frame.Border:SetFrameLevel(parent:GetFrameLevel())
-  frame.Cooldown = Addon.CreateCooldown(frame, HideOmniCC)
-
-  frame.Highlight = _G.CreateFrame("Frame", nil, frame)
-  frame.Highlight:SetFrameLevel(parent:GetFrameLevel())
-  frame.Highlight:SetPoint("CENTER")
-
-  -- Use a seperate frame for text elements as a) using frame as parent results in the text being shown below
-  -- the cooldown frame and b) using the cooldown frame results in the text not being visible if there is no
-  -- cooldown (i.e., duration and expiration are nil which is true for auras with unlimited duration)
-  local text_frame = _G.CreateFrame("Frame", nil, frame)
-  text_frame:SetFrameLevel(parent:GetFrameLevel())
-  text_frame:SetAllPoints(frame.Icon)
-  frame.Stacks = text_frame:CreateFontString(nil, "OVERLAY")
-  frame.TimeLeft = text_frame:CreateFontString(nil, "OVERLAY")
-
-  frame:Hide()
-
-  return frame
-end
-
-local function UpdateAuraFrameIconMode(self, frame)
-  local db = self.db_widget
-
-  frame.Cooldown:SetShownSwipe(db.ShowCooldownSpiral, HideOmniCC)
-  if ShowDuration then
-    frame.TimeLeft:Show()
-  else
-    frame.TimeLeft:Hide()
-  end
-
-  -- Add tooltips to icons
-
-  if db.ShowTooltips then
-    frame:SetScript("OnEnter", AuraFrameOnEnter)
-    frame:SetScript("OnLeave", AuraFrameOnLeave)
-  else
-    frame:SetScript("OnEnter", nil)
-    frame:SetScript("OnLeave", nil)
-  end
-  -- Setting the OnEnter/Leave, OnMouseDown/Up script automatically implies EnableMouse(true)
-  -- And with that, right clicking and moving the camera does not work anymore when hovering over an aura.
-  frame:EnableMouse(false)
-  frame:SetMouseMotionEnabled(true)
-
-  db = self.db
-
-  -- Icon
-  frame:SetSize(db.IconWidth, db.IconHeight)
-  frame.Icon:SetAllPoints(frame)
-  --frame.Icon:SetTexCoord(.07, 1-.07, .23, 1-.23) -- Style: Widee
-  frame.Icon:SetTexCoord(.10, 1-.07, .12, 1-.12)  -- Style: Square - remove border from icons
-
-  if db.ShowBorder then
-    local offset, edge_size, inset = 2, 8, 0
-    frame.Border:ClearAllPoints()
-    frame.Border:SetPoint("TOPLEFT", frame, "TOPLEFT", -offset, offset)
-    frame.Border:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", offset, -offset)
-    frame.Border:SetBackdrop({
-      edgeFile = Widget.TEXTURE_BORDER,
-      edgeSize = edge_size,
-      insets = { left = inset, right = inset, top = inset, bottom = inset },
-    })
-    frame.Border:SetBackdropBorderColor(0, 0, 0, 1)
-    frame.Border:Show()
-
-  else
-    frame.Border:Hide()
-  end
-
-  AuraHighlightStopPrevious(frame.Highlight)
-  if AuraHighlightEnabled then
-    frame.Highlight:SetSize(frame:GetWidth() + AuraHighlightOffset, frame:GetHeight() + AuraHighlightOffset)
-  end
-
-  FontUpdateText(frame, frame.TimeLeft, db.Duration)
-  FontUpdateText(frame, frame.Stacks, db.StackCount)
-end
-
-local function UpdateAuraInformationIconMode(self, aura_frame) -- texture, duration, expiration, stacks, color, name)
-  local duration = aura_frame.AuraData.duration
-  local expiration = aura_frame.AuraData.expirationTime
-  local stacks = aura_frame.AuraData.applications
-  local color = aura_frame.AuraData.color
-  
-  -- Expiration
-  self:UpdateWidgetTime(aura_frame, expiration, duration)
-
-  local db_widget = self.db_widget
-  if db_widget.ShowStackCount then
-    local stacks = GetAuraApplicationDisplayCount(aura_frame.unitid, aura_frame.AuraData.auraInstanceID)
-    aura_frame.Stacks:SetText(stacks)
-    aura_frame.Stacks:Show()
-  else
-    aura_frame.Stacks:Hide()
-  end
-
-  aura_frame.Icon:SetTexture(aura_frame.AuraData.icon)
-
-  -- Highlight Coloring
-  if self.db.ShowBorder then
-    if db_widget.ShowAuraType then
-      aura_frame.Border:SetBackdropBorderColor(color.r, color.g, color.b, 1)
-    end
-  end
-
-  if not IsSecretValueTP(duration) then
-    if AuraHighlightEnabled then
-      if aura_frame.AuraData.isStealable then
-        AuraHighlightStart(aura_frame.Highlight, AuraHighlightColor, 0)
-      else
-        AuraHighlightStop(aura_frame.Highlight)
-      end
-    end
-    
-    aura_frame.Cooldown:Set(expiration - duration, duration + .25)
-    AnimationStopFlash(aura_frame)
-  end
-  
-  aura_frame:Show()
-end
-
--- local AbbrevOptions = {
---    breakpointData= {
---       {breakpoint = 3600, fractionDivisor = 3600, significandDivisor = 1/1, abbreviation = "", abbreviationIsGlobal = false}, 
---       {breakpoint = 60, fractionDivisor = 60, significandDivisor = 1/1, abbreviation = "", abbreviationIsGlobal = false},
---       {breakpoint = 0, fractionDivisor = 1, significandDivisor = 1/1, abbreviation = "", abbreviationIsGlobal = false}
--- }}
-
--- local AbbrevOptionsUnit = {
---    breakpointData= {
---       {breakpoint = 3600, fractionDivisor = 3600, significandDivisor = 1/1, abbreviation = "h", abbreviationIsGlobal = false}, 
---       {breakpoint = 60, fractionDivisor = 60, significandDivisor = 1/1, abbreviation = "m", abbreviationIsGlobal = false},
---       {breakpoint = 0, fractionDivisor = 1, significandDivisor = 1/1, abbreviation = "", abbreviationIsGlobal = false}
--- }}
-
--- local function GetAbbreviatedTime(seconds)
---   return AbbreviateNumbers(seconds, AbbrevOptions)
--- end
-
--- local TimeFormatter = CreateFromMixins(SecondsFormatterMixin)
--- TimeFormatter:Init(0, SecondsFormatter.Abbreviation.OneLetter, false, true)
--- TimeFormatter:Init(
---   SecondsFormatterConstants.ZeroApproximationThreshold,
---   SecondsFormatter.Abbreviation.OneLetter,
---   SecondsFormatterConstants.DontRoundUpLastUnit,
---   SecondsFormatterConstants.ConvertToLower,
---   SecondsFormatterConstants.RoundUpIntervals)
--- TimeFormatter:SetDesiredUnitCount(1)
--- TimeFormatter:SetMinInterval(SecondsFormatter.Interval.Minutes)
--- TimeFormatter:SetStripIntervalWhitespace(true)
-
-local function UpdateWidgetTimeIconMode(self, aura_frame, expiration, duration)
-  local timeleft = GetAuraDuration(aura_frame:GetParent().unitid, aura_frame.AuraData.auraInstanceID)
-  if timeleft then
-    aura_frame.TimeLeft:SetAlphaFromBoolean(timeleft:IsZero(), 0, 1)
-    -- -- "%.1f"    
-    aura_frame.TimeLeft:SetFormattedText("%d", timeleft:GetRemainingDuration())
-
-    -- Unit is hostile and debuff - short duration format
-    -- if (Addon.GetUnitReactionToPlayer(unitid) < 5) and aura_frame.isHarmful then
-    -- -- "%.1f"    
-    --   aura_frame.TimeLeft:SetFormattedText("%d", timeleft:GetRemainingDuration())
-    -- else
-    --   aura_frame.TimeLeft:SetText(TimeFormatter:Format(timeleft:GetRemainingDuration(), false, true))
-    -- end
-
-    aura_frame.Cooldown:SetCooldownFromDurationObject(timeleft)
-  else
-    aura_frame.TimeLeft:SetText()
-  end
-
-  -- AnimationStopFlash(aura_frame)
-  -- local db_widget = self.db_widget
-  -- if db_widget.FlashWhenExpiring and timeleft < db_widget.FlashTime then
-  --   AnimationFlash(aura_frame)
-  -- end
-end
-
----------------------------------------------------------------------------------------------------
--- Functions for the aura grid with bars
----------------------------------------------------------------------------------------------------
-
-local function CreateAuraFrameBarMode(self, parent)
-  local db = self.db
-  local font = Addon.LibSharedMedia:Fetch('font', db.Font)
-
-  -- frame is probably not necessary, should be ok do add everything to the statusbar frame
-  local frame = _G.CreateFrame("Frame", nil, parent)
-  frame:SetFrameLevel(parent:GetFrameLevel())
-
-  frame.Statusbar = _G.CreateFrame("StatusBar", nil, frame)
-  frame.Statusbar:SetFrameLevel(parent:GetFrameLevel())
-
-  frame.Background = frame.Statusbar:CreateTexture(nil, "BACKGROUND", nil, 0)
-  frame.Background:SetAllPoints()
-
-  frame.Highlight = _G.CreateFrame("Frame", nil, frame)
-  frame.Highlight:SetFrameLevel(parent:GetFrameLevel())
-
-  frame.Icon = frame:CreateTexture(nil, "ARTWORK", nil, -5)
-
-  frame.Stacks = frame.Statusbar:CreateFontString(nil, "OVERLAY")
-  frame.Stacks:SetAllPoints(frame.Icon)
-  --frame.Stacks:SetFont("Fonts\\FRIZQT__.TTF", 11)
-
-  frame.LabelText = frame.Statusbar:CreateFontString(nil, "OVERLAY")
-  frame.LabelText:SetAllPoints(frame.Statusbar)
-  frame.TimeText = frame.Statusbar:CreateFontString(nil, "OVERLAY")
-  frame.TimeText:SetAllPoints(frame.Statusbar)
-
-  frame.Cooldown = Addon.CreateCooldown(frame, HideOmniCC)
-
-  frame:Hide()
-
-  return frame
-end
-
-local function UpdateAuraFrameBarMode(self, frame)
-  local db = self.db_widget
-
-  frame.Cooldown:SetShownSwipe(db.ShowCooldownSpiral, HideOmniCC)
-  if ShowDuration then
-    frame.TimeText:Show()
-  else
-    frame.TimeText:Hide()
-  end
-
-  -- Add tooltips to icons
-  if db.ShowTooltips then
-    frame:SetScript("OnEnter", AuraFrameOnEnter)
-    frame:SetScript("OnLeave", AuraFrameOnLeave)
-  else
-    frame:SetScript("OnEnter", nil)
-    frame:SetScript("OnLeave", nil)
-  end
-  -- Setting the OnEnter/Leave, OnMouseDown/Up script automatically implies EnableMouse(true)
-  -- And with that, right clicking and moving the camera does not work anymore when hovering over an aura.
-  frame:EnableMouse(false)
-  frame:SetMouseMotionEnabled(true)
-
-  db = self.db
-  local font = Addon.LibSharedMedia:Fetch('font', db.Font)
-
-  -- width and position calculations
-  local frame_width = db.BarWidth
-  if db.ShowIcon then
-    frame_width = frame_width + db.BarHeight + db.IconSpacing
-  end
-  frame:SetSize(frame_width, db.BarHeight)
-
-  frame.Background:SetTexture(Addon.LibSharedMedia:Fetch('statusbar', db.BackgroundTexture))
-  frame.Background:SetVertexColor(db.BackgroundColor.r, db.BackgroundColor.g, db.BackgroundColor.b, db.BackgroundColor.a)
-
-  frame.Icon:ClearAllPoints()
-  frame.Statusbar:ClearAllPoints()
-
-  if db.ShowIcon then
-    if db.IconAlignmentLeft then
-      frame.Icon:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 0, 0)
-      frame.Statusbar:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", db.BarHeight + db.IconSpacing, 0)
-    else
-      frame.Icon:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", db.BarWidth + db.IconSpacing, 0)
-      frame.Statusbar:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 0, 0)
-    end
-
-    FontUpdateText(frame.Icon, frame.Stacks, db.StackCount)
-
-    frame.Icon:SetTexCoord(0, 1, 0, 1)
-    frame.Icon:SetSize(db.BarHeight, db.BarHeight)
-    frame.Icon:Show()
-  else
-    frame.Statusbar:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 0, 0)
-    frame.Icon:Hide()
-  end
-
-  FontUpdateText(frame.Statusbar, frame.LabelText, db.Label)
-  FontUpdateText(frame.Statusbar, frame.TimeText, db.Duration)
-
-  AuraHighlightStopPrevious(frame.Highlight)
-  if AuraHighlightEnabled then
-    local aura_highlight = frame.Highlight
-
-    aura_highlight:ClearAllPoints()
-    if self.db_widget.Highlight.Type == "ActionButton" then
-      -- Align to icon because of bad scaling otherwise
-      local offset = - (AuraHighlightOffset * 0.5)
-      if db.IconAlignmentLeft then
-        aura_highlight:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", offset, offset)
-      else
-        aura_highlight:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", db.BarWidth + db.IconSpacing + offset, offset)
-      end
-      aura_highlight:SetSize(db.BarHeight + AuraHighlightOffset, db.BarHeight + AuraHighlightOffset)
-    else
-      aura_highlight:SetPoint("CENTER")
-      aura_highlight:SetSize(frame:GetWidth() + AuraHighlightOffset, frame:GetHeight() + AuraHighlightOffset)
-    end
-  end
-
-  frame.Statusbar:SetSize(db.BarWidth, db.BarHeight)
-  frame.Statusbar:SetStatusBarTexture(Addon.LibSharedMedia:Fetch('statusbar', db.Texture))
-  frame.Statusbar:GetStatusBarTexture():SetHorizTile(false)
-  frame.Statusbar:GetStatusBarTexture():SetVertTile(false)
-end
-
-local function UpdateAuraInformationBarMode(self, aura_frame) -- texture, duration, expiration, stacks, color, name)
-  local db = self.db
-
-  local duration = aura_frame.AuraData.duration
-  local expiration = aura_frame.AuraData.expirationTime
-  local stacks = aura_frame.AuraData.applications
-  local color = aura_frame.AuraData.color
-
-  if self.db_widget.ShowStackCount then
-    local stacks = GetAuraApplicationDisplayCount(aura_frame.unitid, aura_frame.AuraData.auraInstanceID)
-    
-     -- Stacks are either shown on the icon or as postfix to the aura name when
-    -- a) OmniCC is enabled (which shows the CD on the icon) or the icon is disabled
-    if not db.ShowIcon or not HideOmniCC then
-      aura_frame.Stacks:Hide()
-      aura_frame.AuraData.name = aura_frame.AuraData.name .. " (" .. stacks .. ")"
-    else
-      aura_frame.Stacks:SetText(stacks)
-      aura_frame.Stacks:Show()
-    end
-  else
-    aura_frame.Stacks:Hide()
-  end
-
-  -- Icon
-  if db.ShowIcon then
-    aura_frame.Icon:SetTexture(aura_frame.AuraData.icon)
-  end
-
-  if not IsSecretValueTP(duration) then
-    -- if AuraHighlightEnabled then
-    --   if aura_frame.AuraData.isStealable then
-    --     AuraHighlightStart(aura_frame.Highlight, AuraHighlightColor, 0)
-    --   else
-    --     AuraHighlightStop(aura_frame.Highlight)
-    --   end
-    -- end
-
-    aura_frame.Cooldown:Set(duration, expiration)
-    AnimationStopFlash(aura_frame)
-  end
-
-  aura_frame.LabelText:SetText(aura_frame.AuraData.name)
-  aura_frame.Statusbar:SetStatusBarColor(color.r, color.g, color.b, color.a or 1)
-
-  self:UpdateWidgetTime(aura_frame, expiration, duration)
-
-  aura_frame:Show()
-end
-
-local function UpdateWidgetTimeBarMode(self, aura_frame, expiration, duration)
-  local timeleft = GetAuraDuration(aura_frame.unitid, aura_frame.AuraData.auraInstanceID)
-  if timeleft then
-    aura_frame.TimeText:SetAlphaFromBoolean(timeleft:IsZero(), 0, 1)
-    aura_frame.TimeText:SetFormattedText("%d", timeleft:GetRemainingDuration())
-    aura_frame.Cooldown:SetCooldownFromDurationObject(timeleft)
-  
-    aura_frame.Statusbar:SetTimerDuration(timeleft, AuraBarInterpolation, RemainingTimeDirection)
-
-    local color = aura_frame.AuraData.color
-    local bg_color = self.db.BackgroundColor
-    
-    local color = EvaluateColorValueFromBoolean(timeleft:IsZero(), color, bg_color)
-
-    aura_frame.Background:SetVertexColor(color:GetRGBA())
-  else
-    aura_frame.TimeText:SetText()
-  end
-
-  -- if timeleft then
-  --   aura_frame.TimeText:SetAlphaFromBoolean(timeleft:IsZero(), 0, 1)
-
-  --   if timeleft:GetTotalDuration() == 0 then
-  --     aura_frame.Statusbar:SetValue(100)
-  --     --AnimationStopFlash(aura_frame)
-  --   -- elseif expiration == 0 then
-  --   --   aura_frame.TimeText:SetText("")
-  --   --   aura_frame.Statusbar:SetValue(0)
-  --     --AnimationStopFlash(aura_frame)
-  --   else
-  --     local db = self.db_widget
-     
-
-      -- if db.FlashWhenExpiring and timeleft < db.FlashTime then
-      --   AnimationFlash(aura_frame)
-      -- end
-
-  --     aura_frame.Statusbar:SetTimerDuration(timeleft, 0)
-  --   end
-  -- else
-  --   aura_frame.TimeText:SetText()
-  -- end
-end
-
-local function UpdateWidgetTimeBarModeNoDuration(self, aura_frame, expiration, duration)
-  if duration == 0 then
-    aura_frame.Statusbar:SetValue(100)
-    --AnimationStopFlash(aura_frame)
-  elseif expiration == 0 then
-    aura_frame.Statusbar:SetValue(0)
-    --AnimationStopFlash(aura_frame)
-  else
-    local timeleft = expiration - GetTime()
-    if timeleft > 60 then
-      aura_frame.TimeText:SetText(floor(timeleft/60).."m")
-    else
-      aura_frame.TimeText:SetText(floor(timeleft))
-    end
-
-    local db = self.db_widget
-    if db.FlashWhenExpiring and timeleft < db.FlashTime then
-      AnimationFlash(aura_frame)
-    end
-
-    aura_frame.Statusbar:SetValue(timeleft * 100 / duration)
-  end
-end
-
----------------------------------------------------------------------------------------------------
---    if frame and frame.Active then
---      local widget_frame = frame.widgets.Auras
---      local unit = frame.unit
---
---      if widget_frame.Active and unit.HasUnlimitedAuras then
---        unit.InCombat = _G.UnitAffectingCombat(unit.unitid)
---        self:UpdateIconGrid(widget_frame, unit)
---      end
---    end
---  end
---end
--- Widget functions for creation and update
----------------------------------------------------------------------------------------------------
 
 function Widget:Create(tp_frame)
-  -- Required Widget Code
-  local widget_frame = _G.CreateFrame("Frame", nil, tp_frame)
+  local widget_frame = CreateFrame("Frame", nil, tp_frame)
   widget_frame:Hide()
-
-  -- Custom Code
-  --------------------------------------
   widget_frame:SetAllPoints(tp_frame)
-
-  widget_frame.Buffs = self.Buffs:Create(widget_frame)
-  widget_frame.Debuffs = self.Debuffs:Create(widget_frame)
-  widget_frame.CrowdControl = self.CrowdControl:Create(widget_frame)
-
   widget_frame.Widget = self
 
+  widget_frame.Buffs = CreateAuraContainer(widget_frame, "Buffs")
+  widget_frame.Debuffs = CreateAuraContainer(widget_frame, "Debuffs")
+  widget_frame.CrowdControl = CreateAuraContainer(widget_frame, "CrowdControl")
+
   self:UpdateLayout(widget_frame)
-
-  widget_frame:HookScript("OnShow", OnShowHookScript)
-  -- widget_frame:HookScript("OnHide", OnHideHookScript)
-  --------------------------------------
-  -- End Custom Code
-
   return widget_frame
 end
 
@@ -1377,15 +699,10 @@ end
 
 function Widget:OnEnable()
   self:SubscribeEvent("PLAYER_TARGET_CHANGED")
-  self:SubscribeEvent("PLAYER_REGEN_ENABLED")
-  self:SubscribeEvent("PLAYER_REGEN_DISABLED")
-  self:SubscribeEvent("UNIT_AURA")
-  -- LOSS_OF_CONTROL_ADDED
-  -- LOSS_OF_CONTROL_UPDATE
 end
 
 function Widget:EnabledForStyle(style, unit)
-  if (style == "NameOnly" or style == "NameOnly-Unique") then
+  if style == "NameOnly" or style == "NameOnly-Unique" then
     return self.db.ShowInHeadlineView or Addon.ActiveAuraTriggers
   elseif style ~= "etotem" then
     return self.db.ON or Addon.ActiveAuraTriggers
@@ -1396,171 +713,127 @@ function Widget:OnUnitAdded(widget_frame, unit)
   self:UpdateAuras(widget_frame, unit)
 end
 
--- function Widget:OnUnitRemoved(widget_frame, unit)
--- end
+function Widget:OnUnitRemoved(widget_frame, unit)
+  if widget_frame.Buffs.SetEnabled then
+    widget_frame.Buffs:SetEnabled(false)
+    widget_frame.Debuffs:SetEnabled(false)
+    widget_frame.CrowdControl:SetEnabled(false)
+  end
+  widget_frame:Hide()
+end
+
+function Widget:PLAYER_TARGET_CHANGED()
+  if not self.db.ShowTargetOnly then
+    return
+  end
+
+  if self.CurrentTarget then
+    self.CurrentTarget:Hide()
+    if self.CurrentTarget.Buffs.SetEnabled then
+      self.CurrentTarget.Buffs:SetEnabled(false)
+      self.CurrentTarget.Debuffs:SetEnabled(false)
+      self.CurrentTarget.CrowdControl:SetEnabled(false)
+    end
+    self.CurrentTarget = nil
+  end
+
+  local tp_frame = Addon:GetThreatPlateForTarget()
+  if tp_frame then
+    self.CurrentTarget = tp_frame.widgets.Auras
+    if self.CurrentTarget and self.CurrentTarget.Active then
+      self:UpdateAuras(self.CurrentTarget, tp_frame.unit)
+    end
+  end
+end
+
+---------------------------------------------------------------------------------------------------
+-- Settings
+---------------------------------------------------------------------------------------------------
 
 local function ParseFilter(filter_by_spell)
-  local filter = {}
-  local only_player_auras = true
+  local include, exclude = {}, {}
+  if type(filter_by_spell) ~= "table" then
+    return include, exclude
+  end
 
-  local modifier, spell
-  for key, value in pairs(filter_by_spell) do
-    -- remove comments and whitespaces from the filter (string)
-    local pos = value:find("%-%-")
-    if pos then value = value:sub(1, pos - 1) end
-    value = value:match("^%s*(.-)%s*$")  -- remove any leading/trailing whitespaces from the line
+  for _, value in pairs(filter_by_spell) do
+    if type(value) == "string" then
+      local pos = value:find("%-%-")
+      if pos then
+        value = value:sub(1, pos - 1)
+      end
+      value = value:match("^%s*(.-)%s*$")
 
-    -- value:match("^%s*(%w+)%s*(.-)%s*$")  -- remove any leading/trailing whitespaces from the line
-    if value:sub(1, 4) == "All " then
-      modifier = "All"
-      spell = value:match("^All%s*(.-)$")
-      only_player_auras = false
-    elseif value:sub(1, 3) == "My " then
-      modifier = "My"
-      spell = value:match("^My%s*(.-)$")
-    elseif value:sub(1, 4) == "Not " then
-      modifier = "Not"
-      spell = value:match("^Not%s*(.-)$")
-      only_player_auras = false
-    else
-      modifier = true
-      spell = value
-    end
+      local modifier, spell
+      if value:sub(1, 4) == "All " then
+        modifier = "All"
+        spell = value:match("^All%s*(.-)$")
+      elseif value:sub(1, 3) == "My " then
+        modifier = "My"
+        spell = value:match("^My%s*(.-)$")
+      elseif value:sub(1, 4) == "Not " then
+        modifier = "Not"
+        spell = value:match("^Not%s*(.-)$")
+      else
+        modifier = true
+        spell = value
+      end
 
-    -- separete filter by name and ID for more efficient aura filtering
-    local spell_no = tonumber(spell)
-    if spell_no then
-      filter[spell_no] = modifier
-    elseif spell ~= '' then
-      filter[spell] = modifier
+      local spell_id = GetSpellIDFromIdentifier(spell)
+      if spell_id then
+        if modifier == "Not" then
+          -- "Not" entries are ignore-rules for blacklist semantics; skip for include lists.
+        else
+          include[spell_id] = true
+          exclude[spell_id] = true
+        end
+      end
     end
   end
 
-  return filter
+  return include, exclude
 end
 
 function Widget:ParseSpellFilters()
   self.db = Addon.db.profile.AuraWidget
+  local buff_include, buff_exclude = ParseFilter(self.db.Buffs.FilterBySpell)
+  local debuff_include, debuff_exclude = ParseFilter(self.db.Debuffs.FilterBySpell)
+  local cc_include, cc_exclude = ParseFilter(self.db.CrowdControl.FilterBySpell)
 
-  self.AuraFilterBuffs = ParseFilter(self.db.Buffs.FilterBySpell)
-  self.AuraFilterDebuffs = ParseFilter(self.db.Debuffs.FilterBySpell)
-  self.AuraFilterCrowdControl = ParseFilter(self.db.CrowdControl.FilterBySpell)
+  AuraFilterSpellIDs.Buffs.include, AuraFilterSpellIDs.Buffs.exclude = buff_include, buff_exclude
+  AuraFilterSpellIDs.Debuffs.include, AuraFilterSpellIDs.Debuffs.exclude = debuff_include, debuff_exclude
+  AuraFilterSpellIDs.CrowdControl.include, AuraFilterSpellIDs.CrowdControl.exclude = cc_include, cc_exclude
 end
 
--- function Widget:UpdateSizeDataIconMode(aura_grid, db)
---   aura_grid.AuraWidth = db.IconWidth + db.ColumnSpacing
---   aura_grid.AuraHeight = db.IconHeight + db.RowSpacing
---   aura_grid.RowSpacing = db.RowSpacing
---   aura_grid.ColumnSpacing = db.ColumnSpacing
-
---   aura_grid.AuraWidgetWidth = (db.IconWidth * db.Columns) + (db.ColumnSpacing * db.Columns) - db.ColumnSpacing + (aura_grid.AuraWidgetOffset * 2)
---   aura_grid.AuraWidgetHeight = (db.IconHeight * db.Rows) + (db.RowSpacing * db.Rows) - db.RowSpacing + (aura_grid.AuraWidgetOffset * 2)
-
---   for i = 1, db.Columns do
---     local active_auras_width = (db.IconWidth * i) + (db.ColumnSpacing * i) - db.ColumnSpacing + (aura_grid.AuraWidgetOffset * 2)
---     aura_grid.CenterAurasPositions[i] = (aura_grid.AuraWidgetWidth - active_auras_width) / 2
---   end
--- end
-
-function Widget:UpdateSettingsIconMode(aura_type, filter)
+function Widget:UpdateSettingsIconMode(aura_type)
   local aura_grid = self[aura_type]
-
   local db = self.db[aura_type].ModeIcon
   aura_grid.db = db
   aura_grid.db_widget = self.db
-
-  aura_grid.UpdateInterval = Addon.ON_UPDATE_INTERVAL
-  aura_grid.AlignLayout = GRID_LAYOUT[self.db[aura_type].AlignmentH][self.db[aura_type].AlignmentV]
-
+  aura_grid.IconMode = true
   aura_grid.Columns = db.Columns
   aura_grid.MaxAuras = min(db.MaxAuras, db.Rows * db.Columns)
-
-  aura_grid.AuraWidgetOffset = (self.db.ShowAuraType and 2) or 1
-
-  aura_grid.AuraWidth = db.IconWidth + db.ColumnSpacing
-  aura_grid.AuraHeight = db.IconHeight + db.RowSpacing
-  aura_grid.RowSpacing = db.RowSpacing
+  aura_grid.IconWidth = db.IconWidth
+  aura_grid.IconHeight = db.IconHeight
   aura_grid.ColumnSpacing = db.ColumnSpacing
-
-  aura_grid.AuraWidgetWidth = (db.IconWidth * db.Columns) + (db.ColumnSpacing * db.Columns) - db.ColumnSpacing + (aura_grid.AuraWidgetOffset * 2)
-  aura_grid.AuraWidgetHeight = (db.IconHeight * db.Rows) + (db.RowSpacing * db.Rows) - db.RowSpacing + (aura_grid.AuraWidgetOffset * 2)
-
-  for i = 1, db.Columns do
-    local active_auras_width = (db.IconWidth * i) + (db.ColumnSpacing * i) - db.ColumnSpacing + (aura_grid.AuraWidgetOffset * 2)
-    aura_grid.CenterAurasPositions[i] = (aura_grid.AuraWidgetWidth - active_auras_width) / 2
-  end
-
-  aura_grid.CreateAuraFrame = CreateAuraFrameIconMode
-  aura_grid.UpdateAuraFrame = UpdateAuraFrameIconMode
-  aura_grid.UpdateAuraInformation = UpdateAuraInformationIconMode
-  aura_grid.UpdateWidgetTime = UpdateWidgetTimeIconMode
-
-  aura_grid.Create = CreateAuraGrid
-  aura_grid.GetAuraFrame = GetAuraFrame
-  aura_grid.UpdateAuraFramePosition = UpdateAuraFramePosition
-  aura_grid.HideNonActiveAuras = HideNonActiveAuras
+  aura_grid.RowSpacing = db.RowSpacing
 end
 
-
--- function Widget:UpdateSizeDataBarMode(aura_grid, db)
---   aura_grid.AuraWidth = db.BarWidth
---   aura_grid.AuraHeight = db.BarHeight + db.BarSpacing
---   aura_grid.RowSpacing = db.BarSpacing
---   aura_grid.ColumnSpacing = 0
-
---   if db.ShowIcon then
---     aura_grid.AuraWidgetWidth = db.BarWidth + db.BarHeight + db.IconSpacing
---   else
---     aura_grid.AuraWidgetWidth = db.BarWidth
---   end
---   aura_grid.AuraWidgetHeight = (db.BarHeight * db.MaxBars) + (db.BarSpacing * db.MaxBars) - db.BarSpacing + (aura_grid.AuraWidgetOffset * 2)
--- end
-
-function Widget:UpdateSettingsBarMode(aura_type, filter)
+function Widget:UpdateSettingsBarMode(aura_type)
   local aura_grid = self[aura_type]
-
   local db = self.db[aura_type].ModeBar
   aura_grid.db = db
   aura_grid.db_widget = self.db
-
-  aura_grid.UpdateInterval = 1 / GetFramerate()
-  aura_grid.AlignLayout = GRID_LAYOUT[self.db[aura_type].AlignmentH][self.db[aura_type].AlignmentV]
-
+  -- Bar mode cannot show aura names while auras are secret. Use stacked icons instead.
+  aura_grid.IconMode = false
   aura_grid.Columns = 1
   aura_grid.MaxAuras = db.MaxBars
-
-  aura_grid.AuraWidgetOffset = 0
-
-  aura_grid.AuraWidth = db.BarWidth
-  aura_grid.AuraHeight = db.BarHeight + db.BarSpacing
-  aura_grid.RowSpacing = db.BarSpacing
+  aura_grid.IconWidth = db.ShowIcon and db.BarHeight or db.BarWidth
+  aura_grid.IconHeight = db.BarHeight
   aura_grid.ColumnSpacing = 0
-
-  if db.ShowIcon then
-    aura_grid.AuraWidgetWidth = db.BarWidth + db.BarHeight + db.IconSpacing
-  else
-    aura_grid.AuraWidgetWidth = db.BarWidth
-  end
-  aura_grid.AuraWidgetHeight = (db.BarHeight * db.MaxBars) + (db.BarSpacing * db.MaxBars) - db.BarSpacing + (aura_grid.AuraWidgetOffset * 2)
-
-  aura_grid.CreateAuraFrame = CreateAuraFrameBarMode
-  aura_grid.UpdateAuraFrame = UpdateAuraFrameBarMode
-  aura_grid.UpdateAuraInformation = UpdateAuraInformationBarMode
-
-  if ShowDuration then
-    aura_grid.UpdateWidgetTime = UpdateWidgetTimeBarMode
-  else
-    aura_grid.UpdateWidgetTime = UpdateWidgetTimeBarMode
-  end
-
-  aura_grid.Create = CreateAuraGrid
-  aura_grid.GetAuraFrame = GetAuraFrame
-  aura_grid.UpdateAuraFramePosition = UpdateAuraFramePosition
-  aura_grid.HideNonActiveAuras = HideNonActiveAuras
+  aura_grid.RowSpacing = db.BarSpacing
 end
 
--- Load settings from the configuration which are shared across all aura widgets
--- used (for each widget) in UpdateWidgetConfig
 function Widget:UpdateSettings()
   self.db = Addon.db.profile.AuraWidget
 
@@ -1573,47 +846,21 @@ function Widget:UpdateSettings()
   else
     self:UpdateSettingsBarMode("Buffs")
   end
-
   if self.Debuffs.IconMode then
     self:UpdateSettingsIconMode("Debuffs")
   else
     self:UpdateSettingsBarMode("Debuffs")
   end
-
   if self.CrowdControl.IconMode then
     self:UpdateSettingsIconMode("CrowdControl")
   else
     self:UpdateSettingsBarMode("CrowdControl")
   end
 
-  -- local buffs_size = (self.Buffs.IconMode and max(self.db.Buffs.ModeIcon.IconWidth, self.db.Buffs.ModeIcon.IconHeight)) or self.db.Buffs.ModeBar.BarHeight
-  -- local debuffs_size = (self.Debuffs.IconMode and max(self.db.Debuffs.ModeIcon.IconWidth, self.db.Debuffs.ModeIcon.IconHeight)) or self.db.Debuffs.ModeBar.BarHeight
-
-  -- self.SwitchScaleBuffsFactor = debuffs_size/ buffs_size
-  -- self.SwitchScaleDebuffsFactor = buffs_size / debuffs_size
-
   self:ParseSpellFilters()
 
-  SetNoCooldownCount = OmniCC and OmniCC.Cooldown and OmniCC.Cooldown.SetNoCooldownCount
-  HideOmniCC = not self.db.ShowOmniCC or Addon.ExpansionIsAtLeastMidnight
-
+  HideOmniCC = not self.db.ShowOmniCC
   ShowDuration = self.db.ShowDuration and HideOmniCC
-  --  -- Don't update any widget frame if the widget isn't enabled.
---  if not self:IsEnabled() then return end
-
-  -- Highlighting
-  AuraHighlightEnabled = self.db.Highlight.Enabled
-  local glow_function = CUSTOM_GLOW_FUNCTIONS[self.db.Highlight.Type][1]
-  AuraHighlightStart = CUSTOM_GLOW_WRAPPER_FUNCTIONS[glow_function] or Addon.LibCustomGlow[glow_function]
-  AuraHighlightStopPrevious = AuraHighlightStop or Addon.LibCustomGlow.PixelGlow_Stop
-  AuraHighlightStop = Addon.LibCustomGlow[CUSTOM_GLOW_FUNCTIONS[self.db.Highlight.Type][2]]
-  AuraHighlightOffset = CUSTOM_GLOW_FUNCTIONS[self.db.Highlight.Type][3]
-
-  local color = (self.db.Highlight.CustomColor and self.db.Highlight.Color) or Addon.DEFAULT_SETTINGS.profile.AuraWidget.Highlight.Color
-  AuraHighlightColor[1] = color.r
-  AuraHighlightColor[2] = color.g
-  AuraHighlightColor[3] = color.b
-  AuraHighlightColor[4] = color.a
 
   EnabledForStyle["NameOnly"] = self.db.ShowInHeadlineView
   EnabledForStyle["NameOnly-Unique"] = self.db.ShowInHeadlineView
@@ -1624,153 +871,19 @@ function Widget:UpdateSettings()
   EnabledForStyle["unique"] = self.db.ON
   EnabledForStyle["etotem"] = false
   EnabledForStyle["empty"] = false
-
-  local sort_function = SORT_FUNCTIONS[self.db.SortOrder]
-  if sort_function then  
-    SortFunction = sort_function[self.db.SortReverse and "Reverse" or "Default"]
-  else
-    SortFunction = nil
-  end
 end
 
 ---------------------------------------------------------------------------------------------------
--- Configuration Mode
+-- Configuration / debug
 ---------------------------------------------------------------------------------------------------
-
-local EnabledConfigMode = false
-local Timer
-
-local ConfigModeAuras = {
-  HARMFUL = {},
-  HELPFUL = {}
-}
-
-local DEMO_AURA_ICONS = {
-  Buffs = { 136085, 132179, 135869, 135962, 135902, 136205, 136114, 136148, 132333 },
-  Debuffs = { 132122, 132212, 135812, 135959, 136207, 132273, 135813, 136118, 132155 },
-  CrowdControl = { 132114, 132118, 136071, 135963, 136184, 136175, 135849, 136183, 132316 },
-}
-
-local function GenerateDemoAuras()
-  for no = 1, 40 do
-    -- aura.name, aura.icon, aura.applications, aura.dispelName, aura.duration, aura.expirationTime, aura.sourceUnit,
-    -- aura.isStealable, aura.nameplateShowPersonal, aura.spellId, aura.canApplyAura, aura.isBossAura, _, aura.nameplateShowAll =
-    local random_name = tostring(math.random(1, 40))
-
-    local aura_duration = math.random(3, 120)
-    local aura_expiration = GetTime() + aura_duration
-    local aura_name, aura_texture, aura_stacks, aura_type, aura_caster, aura_spellid, aura_steal, aura_show_all
-    if no % 2 == 0 then
-      aura_name = "Rake" .. random_name
-      aura_texture = DEMO_AURA_ICONS.Debuffs[math.random(1, #DEMO_AURA_ICONS.Debuffs)]
-      aura_stacks, aura_type, aura_caster, aura_spellid, aura_steal, aura_show_all = 3, nil, "player", 1822, false, false
-    else
-      aura_name = "Bash" .. random_name
-      aura_texture = DEMO_AURA_ICONS.CrowdControl[math.random(1, #DEMO_AURA_ICONS.CrowdControl)]
-      aura_stacks, aura_type, aura_caster, aura_spellid, aura_steal, aura_show_all = 2, nil, "player", 5211, false, true
-    end
-    ConfigModeAuras.HARMFUL[no] = { aura_name, aura_texture, aura_stacks, aura_type, aura_duration, aura_expiration, aura_caster, aura_steal, false, aura_spellid, true, false, true, aura_show_all, 1 }
-
-    aura_name = "Regrowth" .. random_name
-    aura_expiration = GetTime() + aura_duration
-    aura_texture = DEMO_AURA_ICONS.Buffs[math.random(1, #DEMO_AURA_ICONS.Buffs)]
-    aura_stacks, aura_type, aura_caster, aura_spellid, aura_steal = 5, "Magic", "nameplate1", 8936, no % 5 == 0
-    ConfigModeAuras.HELPFUL[no] = { aura_name, aura_texture, aura_stacks, aura_type, aura_duration, aura_expiration, aura_caster, aura_steal, false, aura_spellid, true, false, true, false, 1 }
-  end
-end
-
-local function TimerCallback()
-  for no = 40, 1, -1 do
-    local aura = ConfigModeAuras.HARMFUL[no]
-    if aura and aura[6] < GetTime() then
-      table.remove(ConfigModeAuras.HARMFUL, no)
-    end
-    aura = ConfigModeAuras.HELPFUL[no]
-    if aura and aura[6] < GetTime() then
-      table.remove(ConfigModeAuras.HELPFUL, no)
-    end
-  end
-
-  if #ConfigModeAuras.HARMFUL + #ConfigModeAuras.HELPFUL == 0 then
-    GenerateDemoAuras()
-  end
-
-  for _, tp_frame in Addon:GetActiveThreatPlates() do
-    Widget:UpdateAuras(tp_frame.widgets.Auras, tp_frame.unit)
-  end
-end
-
-local function UnitAuraForConfigurationMode(unitid, i, effect)
-  local aura = ConfigModeAuras[effect][i]
-  if aura then
-    return unpack(aura)
-  else
-    return nil
-  end
-end
-
-local function ProcessAllUnitAurasConfigMode(unitid, effect)
-  local unit_auras = {}
-
-  for i = 1, 40 do
-    local aura = {}
-
-    aura.name, aura.icon, aura.applications, aura.dispelName, aura.duration, aura.expirationTime, aura.sourceUnit,
-      aura.isStealable, aura.nameplateShowPersonal, aura.spellId, aura.canApplyAura, aura.isBossAura, aura.castByPlayer, aura.nameplateShowAll =
-      UnitAuraForConfigurationMode(unitid, i, effect)
-
-    if aura.name then 
-      aura.auraInstanceID = i
-      unit_auras[#unit_auras + 1] = aura
-    else
-      break
-    end
-  end
-
-  return unit_auras
-end
-
-local ProcessAllUnitAurasBackup
 
 function Widget:ToggleConfigurationMode()
-  if not EnabledConfigMode then
-    EnabledConfigMode = true
-
-    GenerateDemoAuras()
-    ProcessAllUnitAurasBackup = ProcessAllUnitAuras
-    ProcessAllUnitAuras = ProcessAllUnitAurasConfigMode
-
-    Addon:ForceUpdate()
-    Timer = C_Timer.NewTicker(0.5, TimerCallback)
-  else
-    EnabledConfigMode = false
-
-    ProcessAllUnitAuras = ProcessAllUnitAurasBackup
-    Timer:Cancel()
-
-    Addon:ForceUpdate()
-  end
+  Addon.Logging.Warning("Aura configuration preview is not available in Midnight 12.1 because aura data is secret.")
 end
 
-local ProcessAllUnitAuras_NoDebug = ProcessAllUnitAuras
-
 function Widget:PrintDebug(command)
+  Addon.Logging.Debug("Auras widget is using Blizzard AuraContainer (12.1). GetAuraSlots is no longer called.")
   if command == "enable" then
-    Addon.Logging.Debug("    Debugging mode enabled.")
-    ProcessAllUnitAuras_NoDebug = ProcessAllUnitAuras
-    ProcessAllUnitAuras = function(unitid, effect)
-      local unit_auras = ProcessAllUnitAuras_NoDebug(unitid, effect)
-      
-      for k, aura in pairs(unit_auras) do
-        if aura.sourceUnit == "player" then
-          Addon.Logging.Debug("    Aura:", aura.name, "=> ID:", aura.spellId, "( Dispell:", aura.isStealable, ")")
-        end
-      end
-
-      return unit_auras
-    end
-  else
-    Addon.Logging.Debug("    Debugging mode disabled.")
-    ProcessAllUnitAuras = ProcessAllUnitAuras_NoDebug
+    Addon.Logging.Debug("    Buff whitelist/blacklist IDs:", AuraFilterSpellIDs.Buffs.include and "set" or "none")
   end
 end

--- a/Widgets/WidgetHandler.lua
+++ b/Widgets/WidgetHandler.lua
@@ -335,7 +335,12 @@ function WidgetHandler:OnPlateCreated(tp_frame)
   local plate_widgets = {}
 
   for widget_name, widget in pairs(self.EnabledWidgets) do
-    plate_widgets[widget_name] = widget:Create(tp_frame)
+    local ok, widget_frame = pcall(widget.Create, widget, tp_frame)
+    if ok then
+      plate_widgets[widget_name] = widget_frame
+    else
+      Addon.Logging.Error("Error creating widget '" .. tostring(widget_name) .. "': " .. tostring(widget_frame))
+    end
   end
 
   tp_frame.widgets = plate_widgets
@@ -345,6 +350,9 @@ end
 --       Maybe event seperate style dependedt stuff (PVlateStyleChanged)
 function WidgetHandler:OnUnitAdded(tp_frame, unit)
   local plate_widgets = tp_frame.widgets
+  if not plate_widgets then
+    return
+  end
 
   if unit.IsSoftTarget then
     for _, widget in pairs(self.EnabledTargetWidgets) do
@@ -358,14 +366,15 @@ function WidgetHandler:OnUnitAdded(tp_frame, unit)
 
   for widget_name, widget in pairs(self.EnabledWidgets) do
     local widget_frame = plate_widgets[widget_name]
+    if widget_frame then
+      widget_frame.Active = tp_frame.stylename ~= "empty" and widget:EnabledForStyle(tp_frame.stylename, unit)
+      widget_frame.unit = unit
 
-    widget_frame.Active = tp_frame.stylename ~= "empty" and widget:EnabledForStyle(tp_frame.stylename, unit)
-    widget_frame.unit = unit
-
-    if widget_frame.Active then
-      widget:OnUnitAdded(widget_frame, unit)
-    else
-      widget_frame:Hide()
+      if widget_frame.Active then
+        widget:OnUnitAdded(widget_frame, unit)
+      else
+        widget_frame:Hide()
+      end
     end
   end
 end
@@ -392,13 +401,19 @@ function WidgetHandler:OnUnitRemoved(tp_frame, unit)
   end
 
   local plate_widgets = tp_frame.widgets
+  if not plate_widgets then
+    return
+  end
+
   for widget_name, widget in pairs(self.EnabledWidgets) do
     local widget_frame = plate_widgets[widget_name]
-    widget_frame.Active = false
-    widget_frame:Hide()
+    if widget_frame then
+      widget_frame.Active = false
+      widget_frame:Hide()
 
-    if widget.OnUnitRemoved then
-      widget:OnUnitRemoved(widget_frame, unit)
+      if widget.OnUnitRemoved then
+        widget:OnUnitRemoved(widget_frame, unit)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Replace `AuraUtil.ForEachAura` / `GetAuraSlots` in the Midnight auras widget with Blizzard `AuraContainer` / `AuraButton` APIs so buffs, debuffs, and crowd control still display while auras are secret.
- Keep existing Threat Plates filter modes (all / whitelist / blacklist, mine, dispellable, important, CC) as AuraContainer filter strings and candidate spell ID sets.
- Guard widget creation so a failed aura button init cannot leave `tp_frame.widgets` nil and break all nameplates.

Fixes https://github.com/Backupiseasy/ThreatPlates/issues/723

## Test plan
- [ ] `/reload` on Midnight 12.1 with Auras widget enabled
- [ ] Confirm the `GetAuraSlots(): Auras cannot be accessed when secret while tainted` error no longer appears
- [ ] Confirm nameplates still create (no `plate_widgets` nil errors)
- [ ] Check enemy nameplates in the open world and in combat for player debuffs / CC icons
- [ ] Check whitelist/blacklist spell ID filters still apply
- [ ] Confirm aura options preview reports that configuration mode is unavailable on 12.1


Made with [Cursor](https://cursor.com)