### PR TITLE
Rebuild Auras widget on Patch 12.1.0 AuraContainer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # @project-version@ (@build-time@)
 
-* Fixed a Lua error in the Auras widget when aura highlighting was enabled [GH-719].
-* Updated integrated libraries (LibCustomGlow to 1.0.4-10-g4f8f5c2-alpha).
+* Fix Lua error when displaying auras on nameplates caused by restrictions on secret values [GH-723].
+* Rebuilt the Auras widget on top of Patch 12.1.0's new AuraContainer API, since the old aura-scanning method no longer works reliably. Currently only rudimentary aura features are available as a result.

--- a/Constants.lua
+++ b/Constants.lua
@@ -873,7 +873,6 @@ Addon.DEFAULT_SETTINGS = {
         ShowOnlyMine = true,
         ShowBlizzardForEnemy = false,
         ShowPriority = false, -- candidateFilters.isPriorityAura (Patch 12.1.0)
-        MaxDuration = 0, -- candidateFilters.maxDuration in seconds (Patch 12.1.0), 0 = disabled
         -- ShowDispellable/ShowBoss/FilterByType above are friendly-only (legacy semantics: the old
         -- Enemy filter function never read them, and Enemy Options never exposed them). The enemy
         -- Midnight panel's own Dispellable/Boss/DispelType toggles use these separate fields instead,
@@ -1029,11 +1028,13 @@ Addon.DEFAULT_SETTINGS = {
         ShowOnlyMine = false,
         ShowPlayerCanApply = false,
         ShowFriendlyBigDefensives = false,
+        MaxDurationFriendly = 0, -- candidateFilters.maxDuration in seconds (Patch 12.1.0), 0 = disabled
         ShowEnemy = true,
         ShowAllEnemy = false,
         ShowOnEnemyNPCs = true,
         ShowDispellable = true,
         ShowMagic = false,
+        MaxDurationEnemy = 0, -- candidateFilters.maxDuration in seconds (Patch 12.1.0), 0 = disabled
         ShowUnlimitedAlways = false,
         ShowUnlimitedInCombat = true,
         ShowUnlimitedInInstances = true,

--- a/Constants.lua
+++ b/Constants.lua
@@ -880,19 +880,23 @@ Addon.DEFAULT_SETTINGS = {
         -- so toggling one reaction's checkbox doesn't silently flip the other's.
         ShowDispellableEnemy = false,
         ShowBossEnemy = false,
+        -- Dispel Type ("Bannart") defaults to all types checked, since it's now combined with
+        -- Dispellable ("Bannbar") - it only takes effect once Bannbar is on, and "all types checked"
+        -- is what keeps a freshly-enabled Bannbar showing every dispellable debuff (matching its old,
+        -- type-independent behavior) rather than silently showing nothing.
         FilterByTypeEnemy = {
-          [1] = false,
-          [2] = false,
-          [3] = false,
-          [4] = false,
+          [1] = true,
+          [2] = true,
+          [3] = true,
+          [4] = true,
         },
         FilterMode = "Block",
         FilterBySpell = {},
         FilterByType = {
-          [1] = false,  -- Moved to Debuffs and negated meaning in 8.8.0
-          [2] = false,  -- Moved to Debuffs and negated meaning in 8.8.0
-          [3] = false,  -- Moved to Debuffs and negated meaning in 8.8.0
-          [4] = false,  -- Moved to Debuffs and negated meaning in 8.8.0
+          [1] = true,  -- Moved to Debuffs and negated meaning in 8.8.0
+          [2] = true,  -- Moved to Debuffs and negated meaning in 8.8.0
+          [3] = true,  -- Moved to Debuffs and negated meaning in 8.8.0
+          [4] = true,  -- Moved to Debuffs and negated meaning in 8.8.0
         },
         -- Positioning
         AlignmentH = "LEFT",

--- a/Constants.lua
+++ b/Constants.lua
@@ -872,6 +872,20 @@ Addon.DEFAULT_SETTINGS = {
         ShowAllEnemy = false,
         ShowOnlyMine = true,
         ShowBlizzardForEnemy = false,
+        ShowPriority = false, -- candidateFilters.isPriorityAura (Patch 12.1.0)
+        MaxDuration = 0, -- candidateFilters.maxDuration in seconds (Patch 12.1.0), 0 = disabled
+        -- ShowDispellable/ShowBoss/FilterByType above are friendly-only (legacy semantics: the old
+        -- Enemy filter function never read them, and Enemy Options never exposed them). The enemy
+        -- Midnight panel's own Dispellable/Boss/DispelType toggles use these separate fields instead,
+        -- so toggling one reaction's checkbox doesn't silently flip the other's.
+        ShowDispellableEnemy = false,
+        ShowBossEnemy = false,
+        FilterByTypeEnemy = {
+          [1] = false,
+          [2] = false,
+          [3] = false,
+          [4] = false,
+        },
         FilterMode = "Block",
         FilterBySpell = {},
         FilterByType = {
@@ -1010,6 +1024,7 @@ Addon.DEFAULT_SETTINGS = {
         ShowOnFriendlyNPCs = true,
         ShowOnlyMine = false,
         ShowPlayerCanApply = false,
+        ShowFriendlyBigDefensives = false,
         ShowEnemy = true,
         ShowAllEnemy = false,
         ShowOnEnemyNPCs = true,

--- a/Nameplate.lua
+++ b/Nameplate.lua
@@ -1273,7 +1273,7 @@ end
 
 function Addon.ExecuteOnlyOoC(func)
   if InCombatLockdown() then
-    Addon.Logging.Error(L["Unable to change this setting while in combat"])
+    Addon.Logging.Error(L["Unable to change this setting while in combat."])
   else
     func()
   end

--- a/Options.lua
+++ b/Options.lua
@@ -4120,6 +4120,7 @@ local function CreateAuraAreaLayoutOptions(pos, widget_info)
             set = function(info, val) SetValue(info, true) end,
             get = function(info) return GetValue(info) end,
             arg = { "AuraWidget", widget_info, "ModeBar", "Enabled" },
+            hidden = Addon.ExpansionIsAtLeastMidnight,
           },
         },
       },
@@ -4311,6 +4312,7 @@ local function CreateAuraAreaBarModeOptions(pos, widget_info)
     order = pos,
     type = "group",
     inline = false,
+    hidden = Addon.ExpansionIsAtLeastMidnight,
     args = {
       --Help = { type = "description", order = 0, width = "full", name = L["Show auras as bars (with optional icons)."], },
       Format = {
@@ -4772,9 +4774,10 @@ local function CreateAurasWidgetOptions()
                     arg = { "AuraWidget", "Buffs", "ShowAllFriendly" },
                     set = function(info, val)
                       local db = db.AuraWidget.Buffs
-                      if db.ShowOnFriendlyNPCs or db.ShowOnlyMine or db.ShowFriendlyBigDefensives then
+                      if db.ShowOnFriendlyNPCs or db.ShowOnlyMine or db.ShowPlayerCanApply or db.ShowFriendlyBigDefensives then
                         db.ShowOnFriendlyNPCs = false
                         db.ShowOnlyMine = false
+                        db.ShowPlayerCanApply = false
                         db.ShowFriendlyBigDefensives = false
                         SetValue(info, val)
                       end
@@ -4785,10 +4788,10 @@ local function CreateAurasWidgetOptions()
                     name = L["All on NPCs"],
                     order = 30,
                     type = "toggle",
-                    desc = L["Show all buffs on NPCs."],
+                    desc = L["Show all buffs on NPCs. Like All, but scoped to friendly NPCs only - not freely combinable with Mine/Player Can Apply/Big Defensives on NPC targets."],
                     set = function(info, val)
                       local db = db.AuraWidget.Buffs
-                      db.ShowAllFriendly = not (val or db.ShowOnlyMine or db.ShowFriendlyBigDefensives)
+                      if val then db.ShowAllFriendly = false end
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Buffs", "ShowOnFriendlyNPCs" },
@@ -4803,7 +4806,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show buffs that were applied by you."],
                     set = function(info, val)
                       local db = db.AuraWidget.Buffs
-                      db.ShowAllFriendly = not (db.ShowOnFriendlyNPCs or val or db.ShowFriendlyBigDefensives)
+                      if val then db.ShowAllFriendly = false end
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Buffs", "ShowOnlyMine" },
@@ -4811,21 +4814,34 @@ local function CreateAurasWidgetOptions()
                       return not db.AuraWidget.Buffs.ShowFriendly
                     end
                   },
-                  -- BigDefensive = {
-                  --   name = L["Big Defensives"],
-                  --   order = 60,
-                  --   type = "toggle",
-                  --   desc = L["Show big defensive buffs."],
-                  --   set = function(info, val)
-                  --     local db = db.AuraWidget.Buffs
-                  --     db.ShowAllFriendly = not (db.ShowOnFriendlyNPCs or db.ShowOnlyMine or val)
-                  --     SetValue(info, val)
-                  --   end,
-                  --   arg = { "AuraWidget", "Buffs", "ShowFriendlyBigDefensives" },
-                  --   disabled = function() return not db.AuraWidget.Buffs.ShowFriendly end
-                  -- },
+                  CanApply = {
+                    name = L["Player Can Apply"],
+                    order = 50,
+                    type = "toggle",
+                    desc = L["Show buffs that you could apply yourself (regardless of who actually cast them)."],
+                    set = function(info, val)
+                      local db = db.AuraWidget.Buffs
+                      if val then db.ShowAllFriendly = false end
+                      SetValue(info, val)
+                    end,
+                    arg = { "AuraWidget", "Buffs", "ShowPlayerCanApply" },
+                    disabled = function() return not db.AuraWidget.Buffs.ShowFriendly end
+                  },
+                  BigDefensive = {
+                    name = L["Big Defensives"],
+                    order = 60,
+                    type = "toggle",
+                    desc = L["Show big defensive buffs."],
+                    set = function(info, val)
+                      local db = db.AuraWidget.Buffs
+                      if val then db.ShowAllFriendly = false end
+                      SetValue(info, val)
+                    end,
+                    arg = { "AuraWidget", "Buffs", "ShowFriendlyBigDefensives" },
+                    disabled = function() return not db.AuraWidget.Buffs.ShowFriendly end
+                  },
                 },
-              },              
+              },
               EnemyUnits = {
                 name = L["Enemy Units"],
                 type = "group",
@@ -5004,6 +5020,7 @@ local function CreateAurasWidgetOptions()
                       if val and not db.ShowAllEnemy then
                         db.ShowOnEnemyNPCs = false
                         db.ShowDispellable = false
+                        db.ShowMagic = false
                         SetValue(info, val)
                       end
                     end,
@@ -5016,10 +5033,10 @@ local function CreateAurasWidgetOptions()
                     name = L["All on NPCs"],
                     order = 30,
                     type = "toggle",
-                    desc = L["Show all buffs on NPCs."],
+                    desc = L["Show all buffs on NPCs. Like All, but scoped to enemy NPCs only - not freely combinable with Dispellable/Magic on NPC targets."],
                     set = function(info, val)
                       local db = db.AuraWidget.Buffs
-                      db.ShowAllEnemy = not (val or db.ShowDispellable)
+                      if val then db.ShowAllEnemy = false end
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Buffs", "ShowOnEnemyNPCs" },
@@ -5034,7 +5051,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show buffs that you can dispell."],
                     set = function(info, val)
                       local db = db.AuraWidget.Buffs
-                      db.ShowAllEnemy = not (db.ShowOnEnemyNPCs or val)
+                      if val then db.ShowAllEnemy = false end
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Buffs", "ShowDispellable" },
@@ -5042,8 +5059,23 @@ local function CreateAurasWidgetOptions()
                       return not db.AuraWidget.Buffs.ShowEnemy
                     end
                   },
+                  Magic = {
+                    name = L["Magic"],
+                    order = 60,
+                    type = "toggle",
+                    desc = L["Show buffs of dispel type Magic."],
+                    set = function(info, val)
+                      local db = db.AuraWidget.Buffs
+                      if val then db.ShowAllEnemy = false end
+                      SetValue(info, val)
+                    end,
+                    arg = { "AuraWidget", "Buffs", "ShowMagic" },
+                    disabled = function()
+                      return not db.AuraWidget.Buffs.ShowEnemy
+                    end
+                  },
                 },
-              },              
+              },
               SpellFilter = {
                 name = L["Filter by Spell"],
                 order = 50,
@@ -5051,6 +5083,12 @@ local function CreateAurasWidgetOptions()
                 inline = true,
                 hidden = Addon.ExpansionIsAtLeastMidnight,
                 args = {
+                  ScopeNote = {
+                    name = L["This spell filter only takes effect for buffs on friendly units. On enemy units it has no effect, due to a Blizzard API restriction (Patch 12.1.0)."],
+                    type = "description",
+                    order = 0,
+                    fontSize = "medium",
+                  },
                   Mode = {
                     name = L["Mode"],
                     type = "select",
@@ -5111,6 +5149,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Show Debuffs"],
                     order = 10,
                     type = "toggle",
+                    desc = L["Enable or disable showing debuffs on friendly units altogether."],
                     arg = { "AuraWidget", "Debuffs", "ShowFriendly" },
                   },
                   ShowAll = {
@@ -5183,6 +5222,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Curse"],
                     order = 60,
                     type = "toggle",
+                    desc = L["Show harmful auras of the Curse dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByType[1] end,
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
@@ -5197,6 +5237,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Disease"],
                     order = 70,
                     type = "toggle",
+                    desc = L["Show harmful auras of the Disease dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByType[2] end,
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
@@ -5211,6 +5252,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Magic"],
                     order = 80,
                     type = "toggle",
+                    desc = L["Show harmful auras of the Magic dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByType[3] end,
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
@@ -5225,6 +5267,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Poison"],
                     order = 90,
                     type = "toggle",
+                    desc = L["Show harmful auras of the Poison dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByType[4] end,
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
@@ -5248,6 +5291,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Show Debuffs"],
                     order = 10,
                     type = "toggle",
+                    desc = L["Enable or disable showing debuffs on friendly units altogether."],
                     arg = { "AuraWidget", "Debuffs", "ShowFriendly" },
                   },
                   ShowAll = {
@@ -5255,12 +5299,18 @@ local function CreateAurasWidgetOptions()
                     order = 20,
                     type = "toggle",
                     desc = L["Show all debuffs on friendly units."],
+                    -- "All" subsumes every other toggle below, so turning it on clears them; turning
+                    -- any of them on (see their own set() below) clears "All" instead. Unlike "All",
+                    -- the other toggles are independent and freely combinable with each other.
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                      if db.ShowDispellable then
-                        db.ShowDispellable = false
-                        SetValue(info, val)
-                      end
+                      db.ShowDispellable = false
+                      db.ShowBoss = false
+                      db.FilterByType[1] = false
+                      db.FilterByType[2] = false
+                      db.FilterByType[3] = false
+                      db.FilterByType[4] = false
+                      SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowAllFriendly" },
                     disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end
@@ -5272,11 +5322,85 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show debuffs that you can dispell."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                      db.ShowAllFriendly = not (val)
+                      if val then db.ShowAllFriendly = false end
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowDispellable" },
                     disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end
+                  },
+                  Boss = {
+                    name = L["Boss"],
+                    order = 50,
+                    type = "toggle",
+                    desc = L["Show debuffs that were applied by bosses."],
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllFriendly = false end
+                      SetValue(info, val)
+                    end,
+                    arg = { "AuraWidget", "Debuffs", "ShowBoss" },
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end
+                  },
+                  DispelTypeHeader = {
+                    name = L["Dispel Type"],
+                    type = "header",
+                    order = 80,
+                  },
+                  Curses = {
+                    name = L["Curse"],
+                    order = 90,
+                    type = "toggle",
+                    desc = L["Show harmful auras of the Curse dispel type."],
+                    get = function(info) return db.AuraWidget.Debuffs.FilterByType[1] end,
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllFriendly = false end
+                      db.FilterByType[1] = val
+                      Addon.Widgets:UpdateSettings("Auras")
+                    end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end,
+                  },
+                  Diseases = {
+                    name = L["Disease"],
+                    order = 100,
+                    type = "toggle",
+                    desc = L["Show harmful auras of the Disease dispel type."],
+                    get = function(info) return db.AuraWidget.Debuffs.FilterByType[2] end,
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllFriendly = false end
+                      db.FilterByType[2] = val
+                      Addon.Widgets:UpdateSettings("Auras")
+                    end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end,
+                  },
+                  Magics = {
+                    name = L["Magic"],
+                    order = 110,
+                    type = "toggle",
+                    desc = L["Show harmful auras of the Magic dispel type."],
+                    get = function(info) return db.AuraWidget.Debuffs.FilterByType[3] end,
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllFriendly = false end
+                      db.FilterByType[3] = val
+                      Addon.Widgets:UpdateSettings("Auras")
+                    end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end,
+                  },
+                  Poisons = {
+                    name = L["Poison"],
+                    order = 120,
+                    type = "toggle",
+                    desc = L["Show harmful auras of the Poison dispel type."],
+                    get = function(info) return db.AuraWidget.Debuffs.FilterByType[4] end,
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllFriendly = false end
+                      db.FilterByType[4] = val
+                      Addon.Widgets:UpdateSettings("Auras")
+                    end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end,
                   },
                 },
               },
@@ -5291,6 +5415,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Show Debuffs"],
                     order = 10,
                     type = "toggle",
+                    desc = L["Enable or disable showing debuffs on enemy units altogether."],
                     arg = { "AuraWidget", "Debuffs", "ShowEnemy" }
                   },
                   ShowAll = {
@@ -5349,6 +5474,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Show Debuffs"],
                     order = 10,
                     type = "toggle",
+                    desc = L["Enable or disable showing debuffs on enemy units altogether."],
                     arg = { "AuraWidget", "Debuffs", "ShowEnemy" }
                   },
                   ShowAll = {
@@ -5356,12 +5482,21 @@ local function CreateAurasWidgetOptions()
                     order = 20,
                     type = "toggle",
                     desc = L["Show all debuffs on enemy units."],
+                    -- "All" subsumes every other toggle below, so turning it on clears them; turning
+                    -- any of them on (see their own set() below) clears "All" instead. Unlike "All",
+                    -- the other toggles are independent and freely combinable with each other.
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                      if db.ShowOnlyMine then
-                        db.ShowOnlyMine = false
-                        SetValue(info, val)
-                      end
+                      db.ShowOnlyMine = false
+                      db.ShowBlizzardForEnemy = false
+                      db.ShowBossEnemy = false
+                      db.ShowPriority = false
+                      db.ShowDispellableEnemy = false
+                      db.FilterByTypeEnemy[1] = false
+                      db.FilterByTypeEnemy[2] = false
+                      db.FilterByTypeEnemy[3] = false
+                      db.FilterByTypeEnemy[4] = false
+                      SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowAllEnemy" },
                     disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
@@ -5370,17 +5505,143 @@ local function CreateAurasWidgetOptions()
                     name = L["Mine"],
                     order = 30,
                     type = "toggle",
-                    desc = L["Show debuffs that were applied by you."],
+                    desc = L["Show debuffs that were applied by you (or your pet)."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                      db.ShowAllEnemy = not (val)
+                      if val then db.ShowAllEnemy = false end
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowOnlyMine" },
                     disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
                   },
+                  Blizzard = {
+                    name = L["Blizzard"],
+                    order = 40,
+                    type = "toggle",
+                    desc = L["Show debuffs that are shown on Blizzard's default nameplates."],
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllEnemy = false end
+                      SetValue(info, val)
+                    end,
+                    arg = { "AuraWidget", "Debuffs", "ShowBlizzardForEnemy" },
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                  },
+                  Boss = {
+                    name = L["Boss"],
+                    order = 50,
+                    type = "toggle",
+                    desc = L["Show debuffs that were applied by bosses."],
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllEnemy = false end
+                      SetValue(info, val)
+                    end,
+                    arg = { "AuraWidget", "Debuffs", "ShowBossEnemy" },
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                  },
+                  Priority = {
+                    name = L["Priority"],
+                    order = 60,
+                    type = "toggle",
+                    desc = L["Show debuffs that Blizzard classifies as high priority."],
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllEnemy = false end
+                      SetValue(info, val)
+                    end,
+                    arg = { "AuraWidget", "Debuffs", "ShowPriority" },
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                  },
+                  Dispellable = {
+                    name = L["Dispellable"],
+                    order = 70,
+                    type = "toggle",
+                    desc = L["Show debuffs that can be dispelled."],
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllEnemy = false end
+                      SetValue(info, val)
+                    end,
+                    arg = { "AuraWidget", "Debuffs", "ShowDispellableEnemy" },
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                  },
+                  MaxDuration = {
+                    name = L["Max Duration"],
+                    order = 75,
+                    type = "range",
+                    isPercent = false,
+                    min = 0,
+                    softMin = 0,
+                    softMax = 300,
+                    step = 1,
+                    desc = L["Hide debuffs with a duration longer than this, in seconds (applies on top of the toggles above). 0 disables this filter. Any non-zero value also hides permanent debuffs."],
+                    arg = { "AuraWidget", "Debuffs", "MaxDuration" },
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                  },
+                  DispelTypeHeader = {
+                    name = L["Dispel Type"],
+                    type = "header",
+                    order = 80,
+                  },
+                  Curses = {
+                    name = L["Curse"],
+                    order = 90,
+                    type = "toggle",
+                    desc = L["Show harmful auras of the Curse dispel type."],
+                    get = function(info) return db.AuraWidget.Debuffs.FilterByTypeEnemy[1] end,
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllEnemy = false end
+                      db.FilterByTypeEnemy[1] = val
+                      Addon.Widgets:UpdateSettings("Auras")
+                    end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                  },
+                  Diseases = {
+                    name = L["Disease"],
+                    order = 100,
+                    type = "toggle",
+                    desc = L["Show harmful auras of the Disease dispel type."],
+                    get = function(info) return db.AuraWidget.Debuffs.FilterByTypeEnemy[2] end,
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllEnemy = false end
+                      db.FilterByTypeEnemy[2] = val
+                      Addon.Widgets:UpdateSettings("Auras")
+                    end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                  },
+                  Magics = {
+                    name = L["Magic"],
+                    order = 110,
+                    type = "toggle",
+                    desc = L["Show harmful auras of the Magic dispel type."],
+                    get = function(info) return db.AuraWidget.Debuffs.FilterByTypeEnemy[3] end,
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllEnemy = false end
+                      db.FilterByTypeEnemy[3] = val
+                      Addon.Widgets:UpdateSettings("Auras")
+                    end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                  },
+                  Poisons = {
+                    name = L["Poison"],
+                    order = 120,
+                    type = "toggle",
+                    desc = L["Show harmful auras of the Poison dispel type."],
+                    get = function(info) return db.AuraWidget.Debuffs.FilterByTypeEnemy[4] end,
+                    set = function(info, val)
+                      local db = db.AuraWidget.Debuffs
+                      if val then db.ShowAllEnemy = false end
+                      db.FilterByTypeEnemy[4] = val
+                      Addon.Widgets:UpdateSettings("Auras")
+                    end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                  },
                 },
-              },              
+              },
               SpellFilter = {
                 name = L["Filter by Spell"],
                 order = 50,
@@ -5388,6 +5649,12 @@ local function CreateAurasWidgetOptions()
                 inline = true,
                 hidden = Addon.ExpansionIsAtLeastMidnight,
                 args = {
+                  ScopeNote = {
+                    name = L["This spell filter only takes effect for debuffs on enemy units. On friendly units it has no effect, due to a Blizzard API restriction (Patch 12.1.0)."],
+                    type = "description",
+                    order = 0,
+                    fontSize = "medium",
+                  },
                   Mode = {
                     name = L["Mode"],
                     type = "select",
@@ -5446,6 +5713,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Show Crowd Control"],
                     order = 10,
                     type = "toggle",
+                    desc = L["Enable or disable showing crowd control auras on friendly units altogether."],
                     arg = { "AuraWidget", "CrowdControl", "ShowFriendly" },
                   },
                   ShowAll = {
@@ -5518,6 +5786,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Show Crowd Control"],
                     order = 10,
                     type = "toggle",
+                    desc = L["Enable or disable showing crowd control auras on friendly units altogether."],
                     arg = { "AuraWidget", "CrowdControl", "ShowFriendly" },
                   },
                   ShowAll = {
@@ -5561,6 +5830,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Show Crowd Control"],
                     order = 10,
                     type = "toggle",
+                    desc = L["Enable or disable showing crowd control auras on enemy units altogether."],
                     arg = { "AuraWidget", "CrowdControl", "ShowEnemy" }
                   },
                   ShowAll = {
@@ -5606,6 +5876,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Show Crowd Control"],
                     order = 10,
                     type = "toggle",
+                    desc = L["Enable or disable showing crowd control auras on enemy units altogether."],
                     arg = { "AuraWidget", "CrowdControl", "ShowEnemy" }
                   },
                   ShowAll = {
@@ -5628,6 +5899,12 @@ local function CreateAurasWidgetOptions()
                 inline = true,
                 hidden = Addon.ExpansionIsAtLeastMidnight,
                 args = {
+                  ScopeNote = {
+                    name = L["This spell filter only takes effect for crowd control on enemy units. On friendly units it has no effect, due to a Blizzard API restriction (Patch 12.1.0)."],
+                    type = "description",
+                    order = 0,
+                    fontSize = "medium",
+                  },
                   Mode = {
                     name = L["Mode"],
                     type = "select",

--- a/Options.lua
+++ b/Options.lua
@@ -4840,6 +4840,19 @@ local function CreateAurasWidgetOptions()
                     arg = { "AuraWidget", "Buffs", "ShowFriendlyBigDefensives" },
                     disabled = function() return not db.AuraWidget.Buffs.ShowFriendly end
                   },
+                  MaxDuration = {
+                    name = L["Max Duration"],
+                    order = 70,
+                    type = "range",
+                    isPercent = false,
+                    min = 0,
+                    softMin = 0,
+                    softMax = 300,
+                    step = 1,
+                    desc = L["Hide buffs with a duration longer than this, in seconds (applies on top of the toggles above). 0 disables this filter. Any non-zero value also hides permanent buffs."],
+                    arg = { "AuraWidget", "Buffs", "MaxDurationFriendly" },
+                    disabled = function() return not db.AuraWidget.Buffs.ShowFriendly end,
+                  },
                 },
               },
               EnemyUnits = {
@@ -5073,6 +5086,19 @@ local function CreateAurasWidgetOptions()
                     disabled = function()
                       return not db.AuraWidget.Buffs.ShowEnemy
                     end
+                  },
+                  MaxDuration = {
+                    name = L["Max Duration"],
+                    order = 70,
+                    type = "range",
+                    isPercent = false,
+                    min = 0,
+                    softMin = 0,
+                    softMax = 300,
+                    step = 1,
+                    desc = L["Hide buffs with a duration longer than this, in seconds (applies on top of the toggles above). 0 disables this filter. Any non-zero value also hides permanent buffs."],
+                    arg = { "AuraWidget", "Buffs", "MaxDurationEnemy" },
+                    disabled = function() return not db.AuraWidget.Buffs.ShowEnemy end,
                   },
                 },
               },
@@ -5498,7 +5524,7 @@ local function CreateAurasWidgetOptions()
                     name = L["Blizzard"],
                     order = 40,
                     type = "toggle",
-                    desc = L["Show debuffs that are shown on Blizzard's default nameplates."],
+                    desc = L["Show debuffs applied by you that are also shown on Blizzard's default nameplates."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
                       db.ShowAllEnemy = not (db.ShowOnlyMine or val or db.ShowBossEnemy or db.ShowPriority or db.ShowDispellableEnemy)
@@ -5544,19 +5570,6 @@ local function CreateAurasWidgetOptions()
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowDispellableEnemy" },
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
-                  },
-                  MaxDuration = {
-                    name = L["Max Duration"],
-                    order = 75,
-                    type = "range",
-                    isPercent = false,
-                    min = 0,
-                    softMin = 0,
-                    softMax = 300,
-                    step = 1,
-                    desc = L["Hide debuffs with a duration longer than this, in seconds (applies on top of the toggles above). 0 disables this filter. Any non-zero value also hides permanent debuffs."],
-                    arg = { "AuraWidget", "Debuffs", "MaxDuration" },
                     disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
                   },
                   DispelTypeHeader = {

--- a/Options.lua
+++ b/Options.lua
@@ -4791,7 +4791,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show all buffs on NPCs. Like All, but scoped to friendly NPCs only - not freely combinable with Mine/Player Can Apply/Big Defensives on NPC targets."],
                     set = function(info, val)
                       local db = db.AuraWidget.Buffs
-                      if val then db.ShowAllFriendly = false end
+                      db.ShowAllFriendly = not (val or db.ShowOnlyMine or db.ShowPlayerCanApply or db.ShowFriendlyBigDefensives)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Buffs", "ShowOnFriendlyNPCs" },
@@ -4806,7 +4806,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show buffs that were applied by you."],
                     set = function(info, val)
                       local db = db.AuraWidget.Buffs
-                      if val then db.ShowAllFriendly = false end
+                      db.ShowAllFriendly = not (db.ShowOnFriendlyNPCs or val or db.ShowPlayerCanApply or db.ShowFriendlyBigDefensives)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Buffs", "ShowOnlyMine" },
@@ -4821,7 +4821,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show buffs that you could apply yourself (regardless of who actually cast them)."],
                     set = function(info, val)
                       local db = db.AuraWidget.Buffs
-                      if val then db.ShowAllFriendly = false end
+                      db.ShowAllFriendly = not (db.ShowOnFriendlyNPCs or db.ShowOnlyMine or val or db.ShowFriendlyBigDefensives)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Buffs", "ShowPlayerCanApply" },
@@ -4834,7 +4834,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show big defensive buffs."],
                     set = function(info, val)
                       local db = db.AuraWidget.Buffs
-                      if val then db.ShowAllFriendly = false end
+                      db.ShowAllFriendly = not (db.ShowOnFriendlyNPCs or db.ShowOnlyMine or db.ShowPlayerCanApply or val)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Buffs", "ShowFriendlyBigDefensives" },
@@ -5036,7 +5036,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show all buffs on NPCs. Like All, but scoped to enemy NPCs only - not freely combinable with Dispellable/Magic on NPC targets."],
                     set = function(info, val)
                       local db = db.AuraWidget.Buffs
-                      if val then db.ShowAllEnemy = false end
+                      db.ShowAllEnemy = not (val or db.ShowDispellable or db.ShowMagic)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Buffs", "ShowOnEnemyNPCs" },
@@ -5051,7 +5051,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show buffs that you can dispell."],
                     set = function(info, val)
                       local db = db.AuraWidget.Buffs
-                      if val then db.ShowAllEnemy = false end
+                      db.ShowAllEnemy = not (db.ShowOnEnemyNPCs or val or db.ShowMagic)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Buffs", "ShowDispellable" },
@@ -5066,7 +5066,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show buffs of dispel type Magic."],
                     set = function(info, val)
                       local db = db.AuraWidget.Buffs
-                      if val then db.ShowAllEnemy = false end
+                      db.ShowAllEnemy = not (db.ShowOnEnemyNPCs or db.ShowDispellable or val)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Buffs", "ShowMagic" },
@@ -5159,8 +5159,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show all debuffs on friendly units."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                      if db.ShowBlizzardForFriendly or db.ShowDispellable or db.ShowBoss or
-                        db.FilterByType[1] or db.FilterByType[2] or db.FilterByType[3] or db.FilterByType[4] then
+                      if db.ShowBlizzardForFriendly or db.ShowDispellable or db.ShowBoss then
                         db.ShowBlizzardForFriendly = false
                         db.ShowDispellable = false
                         db.ShowBoss = false
@@ -5177,8 +5176,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show debuffs that are shown on Blizzard's default nameplates."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                        db.ShowAllFriendly = not (val or db.ShowDispellable or db.ShowBoss or
-                        db.FilterByType[1] or db.FilterByType[2] or db.FilterByType[3] or db.FilterByType[4])
+                      db.ShowAllFriendly = not (val or db.ShowDispellable or db.ShowBoss)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowBlizzardForFriendly" },
@@ -5189,11 +5187,10 @@ local function CreateAurasWidgetOptions()
                     name = L["Dispellable"],
                     order = 40,
                     type = "toggle",
-                    desc = L["Show debuffs that you can dispell."],
+                    desc = L["Show debuffs that you can dispell, restricted to the dispel types checked below (Curse/Disease/Magic/Poison)."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                        db.ShowAllFriendly = not (val or db.ShowBlizzardForFriendly or db.ShowBoss or
-                        db.FilterByType[1] or db.FilterByType[2] or db.FilterByType[3] or db.FilterByType[4])
+                      db.ShowAllFriendly = not (val or db.ShowBlizzardForFriendly or db.ShowBoss)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowDispellable" },
@@ -5206,8 +5203,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show debuffs that were applied by bosses."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                        db.ShowAllFriendly = not (val or db.ShowBlizzardForFriendly or db.ShowDispellable or
-                        db.FilterByType[1] or db.FilterByType[2] or db.FilterByType[3] or db.FilterByType[4])
+                      db.ShowAllFriendly = not (val or db.ShowBlizzardForFriendly or db.ShowDispellable)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowBoss" },
@@ -5218,66 +5214,60 @@ local function CreateAurasWidgetOptions()
                     type = "header",
                     order = 50,
                   },
+                  DispelTypeNote = {
+                    name = L["Only takes effect while \"Dispellable\" above is also checked."],
+                    type = "description",
+                    order = 55,
+                    fontSize = "medium",
+                  },
                   Curses = {
                     name = L["Curse"],
                     order = 60,
                     type = "toggle",
-                    desc = L["Show harmful auras of the Curse dispel type."],
+                    desc = L["Show dispellable harmful auras of the Curse dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByType[1] end,
                     set = function(info, val)
-                      local db = db.AuraWidget.Debuffs
-                      db.ShowAllFriendly = not (val or db.ShowBlizzardForFriendly or db.ShowDispellable or db.ShowBoss or
-                        db.FilterByType[2] or db.FilterByType[3] or db.FilterByType[4])
-                      db.FilterByType[1] = val
+                      db.AuraWidget.Debuffs.FilterByType[1] = val
                       Addon.Widgets:UpdateSettings("Auras")
                     end,
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly or not db.AuraWidget.Debuffs.ShowDispellable end,
                   },
                   Diseases = {
                     name = L["Disease"],
                     order = 70,
                     type = "toggle",
-                    desc = L["Show harmful auras of the Disease dispel type."],
+                    desc = L["Show dispellable harmful auras of the Disease dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByType[2] end,
                     set = function(info, val)
-                      local db = db.AuraWidget.Debuffs
-                        db.ShowAllFriendly = not (val or db.ShowBlizzardForFriendly or db.ShowDispellable or db.ShowBoss or
-                        db.FilterByType[1] or db.FilterByType[3] or db.FilterByType[4])
-                        db.FilterByType[2] = val
+                      db.AuraWidget.Debuffs.FilterByType[2] = val
                       Addon.Widgets:UpdateSettings("Auras")
                     end,
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly or not db.AuraWidget.Debuffs.ShowDispellable end,
                   },
                   Magics = {
                     name = L["Magic"],
                     order = 80,
                     type = "toggle",
-                    desc = L["Show harmful auras of the Magic dispel type."],
+                    desc = L["Show dispellable harmful auras of the Magic dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByType[3] end,
                     set = function(info, val)
-                      local db = db.AuraWidget.Debuffs
-                        db.ShowAllFriendly = not (val or db.ShowBlizzardForFriendly or db.ShowDispellable or db.ShowBoss or
-                        db.FilterByType[1] or db.FilterByType[2] or db.FilterByType[4])
-                        db.FilterByType[3] = val
+                      db.AuraWidget.Debuffs.FilterByType[3] = val
                       Addon.Widgets:UpdateSettings("Auras")
                     end,
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly or not db.AuraWidget.Debuffs.ShowDispellable end,
                   },
                   Poisons = {
                     name = L["Poison"],
                     order = 90,
                     type = "toggle",
-                    desc = L["Show harmful auras of the Poison dispel type."],
+                    desc = L["Show dispellable harmful auras of the Poison dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByType[4] end,
                     set = function(info, val)
-                      local db = db.AuraWidget.Debuffs
-                        db.ShowAllFriendly = not (val or db.ShowBlizzardForFriendly or db.ShowDispellable or db.ShowBoss or
-                        db.FilterByType[1] or db.FilterByType[2] or db.FilterByType[3])
-                        db.FilterByType[4] = val
+                      db.AuraWidget.Debuffs.FilterByType[4] = val
                       Addon.Widgets:UpdateSettings("Auras")
                     end,
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end,
-                  },                  
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly or not db.AuraWidget.Debuffs.ShowDispellable end,
+                  },
                 },
               },
               FriendlyUnitsMidnight = {
@@ -5306,10 +5296,6 @@ local function CreateAurasWidgetOptions()
                       local db = db.AuraWidget.Debuffs
                       db.ShowDispellable = false
                       db.ShowBoss = false
-                      db.FilterByType[1] = false
-                      db.FilterByType[2] = false
-                      db.FilterByType[3] = false
-                      db.FilterByType[4] = false
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowAllFriendly" },
@@ -5319,10 +5305,10 @@ local function CreateAurasWidgetOptions()
                     name = L["Dispellable"],
                     order = 40,
                     type = "toggle",
-                    desc = L["Show debuffs that you can dispell."],
+                    desc = L["Show debuffs that you can dispell, restricted to the dispel types checked below (Curse/Disease/Magic/Poison)."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllFriendly = false end
+                      db.ShowAllFriendly = not (val or db.ShowBoss)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowDispellable" },
@@ -5335,7 +5321,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show debuffs that were applied by bosses."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllFriendly = false end
+                      db.ShowAllFriendly = not (db.ShowDispellable or val)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowBoss" },
@@ -5346,61 +5332,59 @@ local function CreateAurasWidgetOptions()
                     type = "header",
                     order = 80,
                   },
+                  DispelTypeNote = {
+                    name = L["Only takes effect while \"Dispellable\" above is also checked."],
+                    type = "description",
+                    order = 85,
+                    fontSize = "medium",
+                  },
                   Curses = {
                     name = L["Curse"],
                     order = 90,
                     type = "toggle",
-                    desc = L["Show harmful auras of the Curse dispel type."],
+                    desc = L["Show dispellable harmful auras of the Curse dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByType[1] end,
                     set = function(info, val)
-                      local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllFriendly = false end
-                      db.FilterByType[1] = val
+                      db.AuraWidget.Debuffs.FilterByType[1] = val
                       Addon.Widgets:UpdateSettings("Auras")
                     end,
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly or not db.AuraWidget.Debuffs.ShowDispellable end,
                   },
                   Diseases = {
                     name = L["Disease"],
                     order = 100,
                     type = "toggle",
-                    desc = L["Show harmful auras of the Disease dispel type."],
+                    desc = L["Show dispellable harmful auras of the Disease dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByType[2] end,
                     set = function(info, val)
-                      local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllFriendly = false end
-                      db.FilterByType[2] = val
+                      db.AuraWidget.Debuffs.FilterByType[2] = val
                       Addon.Widgets:UpdateSettings("Auras")
                     end,
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly or not db.AuraWidget.Debuffs.ShowDispellable end,
                   },
                   Magics = {
                     name = L["Magic"],
                     order = 110,
                     type = "toggle",
-                    desc = L["Show harmful auras of the Magic dispel type."],
+                    desc = L["Show dispellable harmful auras of the Magic dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByType[3] end,
                     set = function(info, val)
-                      local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllFriendly = false end
-                      db.FilterByType[3] = val
+                      db.AuraWidget.Debuffs.FilterByType[3] = val
                       Addon.Widgets:UpdateSettings("Auras")
                     end,
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly or not db.AuraWidget.Debuffs.ShowDispellable end,
                   },
                   Poisons = {
                     name = L["Poison"],
                     order = 120,
                     type = "toggle",
-                    desc = L["Show harmful auras of the Poison dispel type."],
+                    desc = L["Show dispellable harmful auras of the Poison dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByType[4] end,
                     set = function(info, val)
-                      local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllFriendly = false end
-                      db.FilterByType[4] = val
+                      db.AuraWidget.Debuffs.FilterByType[4] = val
                       Addon.Widgets:UpdateSettings("Auras")
                     end,
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowFriendly or not db.AuraWidget.Debuffs.ShowDispellable end,
                   },
                 },
               },
@@ -5492,10 +5476,6 @@ local function CreateAurasWidgetOptions()
                       db.ShowBossEnemy = false
                       db.ShowPriority = false
                       db.ShowDispellableEnemy = false
-                      db.FilterByTypeEnemy[1] = false
-                      db.FilterByTypeEnemy[2] = false
-                      db.FilterByTypeEnemy[3] = false
-                      db.FilterByTypeEnemy[4] = false
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowAllEnemy" },
@@ -5508,7 +5488,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show debuffs that were applied by you (or your pet)."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllEnemy = false end
+                      db.ShowAllEnemy = not (val or db.ShowBlizzardForEnemy or db.ShowBossEnemy or db.ShowPriority or db.ShowDispellableEnemy)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowOnlyMine" },
@@ -5521,7 +5501,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show debuffs that are shown on Blizzard's default nameplates."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllEnemy = false end
+                      db.ShowAllEnemy = not (db.ShowOnlyMine or val or db.ShowBossEnemy or db.ShowPriority or db.ShowDispellableEnemy)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowBlizzardForEnemy" },
@@ -5534,7 +5514,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show debuffs that were applied by bosses."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllEnemy = false end
+                      db.ShowAllEnemy = not (db.ShowOnlyMine or db.ShowBlizzardForEnemy or val or db.ShowPriority or db.ShowDispellableEnemy)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowBossEnemy" },
@@ -5547,7 +5527,7 @@ local function CreateAurasWidgetOptions()
                     desc = L["Show debuffs that Blizzard classifies as high priority."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllEnemy = false end
+                      db.ShowAllEnemy = not (db.ShowOnlyMine or db.ShowBlizzardForEnemy or db.ShowBossEnemy or val or db.ShowDispellableEnemy)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowPriority" },
@@ -5557,10 +5537,10 @@ local function CreateAurasWidgetOptions()
                     name = L["Dispellable"],
                     order = 70,
                     type = "toggle",
-                    desc = L["Show debuffs that can be dispelled."],
+                    desc = L["Show debuffs that can be dispelled, restricted to the dispel types checked below (Curse/Disease/Magic/Poison)."],
                     set = function(info, val)
                       local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllEnemy = false end
+                      db.ShowAllEnemy = not (db.ShowOnlyMine or db.ShowBlizzardForEnemy or db.ShowBossEnemy or db.ShowPriority or val)
                       SetValue(info, val)
                     end,
                     arg = { "AuraWidget", "Debuffs", "ShowDispellableEnemy" },
@@ -5584,61 +5564,59 @@ local function CreateAurasWidgetOptions()
                     type = "header",
                     order = 80,
                   },
+                  DispelTypeNote = {
+                    name = L["Only takes effect while \"Dispellable\" above is also checked."],
+                    type = "description",
+                    order = 85,
+                    fontSize = "medium",
+                  },
                   Curses = {
                     name = L["Curse"],
                     order = 90,
                     type = "toggle",
-                    desc = L["Show harmful auras of the Curse dispel type."],
+                    desc = L["Show dispellable harmful auras of the Curse dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByTypeEnemy[1] end,
                     set = function(info, val)
-                      local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllEnemy = false end
-                      db.FilterByTypeEnemy[1] = val
+                      db.AuraWidget.Debuffs.FilterByTypeEnemy[1] = val
                       Addon.Widgets:UpdateSettings("Auras")
                     end,
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy or not db.AuraWidget.Debuffs.ShowDispellableEnemy end,
                   },
                   Diseases = {
                     name = L["Disease"],
                     order = 100,
                     type = "toggle",
-                    desc = L["Show harmful auras of the Disease dispel type."],
+                    desc = L["Show dispellable harmful auras of the Disease dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByTypeEnemy[2] end,
                     set = function(info, val)
-                      local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllEnemy = false end
-                      db.FilterByTypeEnemy[2] = val
+                      db.AuraWidget.Debuffs.FilterByTypeEnemy[2] = val
                       Addon.Widgets:UpdateSettings("Auras")
                     end,
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy or not db.AuraWidget.Debuffs.ShowDispellableEnemy end,
                   },
                   Magics = {
                     name = L["Magic"],
                     order = 110,
                     type = "toggle",
-                    desc = L["Show harmful auras of the Magic dispel type."],
+                    desc = L["Show dispellable harmful auras of the Magic dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByTypeEnemy[3] end,
                     set = function(info, val)
-                      local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllEnemy = false end
-                      db.FilterByTypeEnemy[3] = val
+                      db.AuraWidget.Debuffs.FilterByTypeEnemy[3] = val
                       Addon.Widgets:UpdateSettings("Auras")
                     end,
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy or not db.AuraWidget.Debuffs.ShowDispellableEnemy end,
                   },
                   Poisons = {
                     name = L["Poison"],
                     order = 120,
                     type = "toggle",
-                    desc = L["Show harmful auras of the Poison dispel type."],
+                    desc = L["Show dispellable harmful auras of the Poison dispel type."],
                     get = function(info) return db.AuraWidget.Debuffs.FilterByTypeEnemy[4] end,
                     set = function(info, val)
-                      local db = db.AuraWidget.Debuffs
-                      if val then db.ShowAllEnemy = false end
-                      db.FilterByTypeEnemy[4] = val
+                      db.AuraWidget.Debuffs.FilterByTypeEnemy[4] = val
                       Addon.Widgets:UpdateSettings("Auras")
                     end,
-                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy end,
+                    disabled = function() return not db.AuraWidget.Debuffs.ShowEnemy or not db.AuraWidget.Debuffs.ShowDispellableEnemy end,
                   },
                 },
               },

--- a/Source/Wiki/AurasFilterCriteria.md
+++ b/Source/Wiki/AurasFilterCriteria.md
@@ -98,30 +98,28 @@ freely-combinable OR-conditions.
 Same freely-combinable multi-group pattern as Debuffs — Enemy below (fewer toggles: no Mine/Blizzard/
 Priority/Max Duration equivalent exposed for friendly): **All** short-circuits everything into a single
 unrestricted group; otherwise Dispellable/Boss/dispel-type are each their own `AddAuraGroup`, cross-
-excluding each other so a multi-matching aura isn't shown twice.
+excluding each other so a multi-matching aura isn't shown twice. **Exception**: Dispellable and Dispel
+Type are combined, not independent — see below.
 
 | Options toggle | Shows | DB field | Technical | Note |
 | --- | --- | --- | --- | --- |
 | Show Debuffs | — | `ShowFriendly` | group master switch | |
 | All | Every debuff on friendly units (except crowd control, which has its own grid) | `ShowAllFriendly` | Crowd Control excluded (own grid) | |
-| Dispellable | Debuffs you can dispel/cleanse | `ShowDispellable` | `DISPELLABLE` token, CC excluded | |
+| Dispellable | Debuffs you can dispel/cleanse, restricted to the dispel types checked below | `ShowDispellable` | `DISPELLABLE` token, CC excluded | |
 | Boss | Debuffs applied by a boss (raid/dungeon encounter) | `ShowBoss` | `candidateFilters.isBossAura = true` | separate DB field from Enemy's `ShowBossEnemy` — changing one doesn't affect the other |
-| Curse / Disease / Magic / Poison | Debuffs of the checked dispel type(s) | `FilterByType[1..4]` | `candidateFilters.includeDispelTypes = {...}` | separate DB field from Enemy's `FilterByTypeEnemy[1..4]`; Dispellable/Boss exclude these checked dispel types from themselves (`excludeDispelTypes`), so a matching aura only shows once, via this group |
+| Curse / Disease / Magic / Poison | Dispellable debuffs of the checked dispel type(s) | `FilterByType[1..4]` | `candidateFilters.includeDispelTypes = {...}` | **combined with Dispellable (2026-08-15)**, not independent — grayed out and inert unless Dispellable is also checked; separate DB field from Enemy's `FilterByTypeEnemy[1..4]`; when active, Boss excludes these checked dispel types from itself (`excludeDispelTypes`), so a matching aura only shows once, via this group; defaults to all four checked |
 
-**Combinations** (Dispel Type = at least one of Curse/Disease/Magic/Poison checked; which specific
-type(s) narrows the result further but doesn't change the combination logic):
+**Combinations** (Dispel Type = at least one of Curse/Disease/Magic/Poison checked; a checked Dispel
+Type only has any effect while Dispellable is also on):
 
 | All | Dispellable | Boss | Dispel Type | Shown |
 | --- | --- | --- | --- | --- |
 | ✅ | – | – | – | Everything (CC excluded) |
-| ❌ | ✅ | ❌ | ❌ | Dispellable only |
-| ❌ | ❌ | ✅ | ❌ | Boss only |
-| ❌ | ❌ | ❌ | ✅ | Checked dispel type(s) only |
-| ❌ | ✅ | ✅ | ❌ | Dispellable ∪ Boss |
-| ❌ | ✅ | ❌ | ✅ | Dispellable ∪ Dispel Type |
-| ❌ | ❌ | ✅ | ✅ | Boss ∪ Dispel Type |
-| ❌ | ✅ | ✅ | ✅ | Union of all three |
-| ❌ | ❌ | ❌ | ❌ | Nothing |
+| ❌ | ✅ | ❌ | ✅ | Dispellable debuffs of the checked type(s) only |
+| ❌ | ✅ | ❌ | ❌ | Nothing from Dispellable (no type checked = no match) |
+| ❌ | ❌ | ✅ | – | Boss only (Dispel Type ignored/grayed out) |
+| ❌ | ✅ | ✅ | ✅ | Boss ∪ (dispellable debuffs of the checked type(s)) |
+| ❌ | ❌ | ❌ | – | Nothing (Dispel Type grayed out, has no effect on its own) |
 
 ## Debuffs — Enemy
 
@@ -136,26 +134,32 @@ duplicated).
 | Blizzard | Debuffs Blizzard itself would show on its own default nameplates | `ShowBlizzardForEnemy` | `IMPORTANT` token | shown on Blizzard's own default nameplates |
 | Boss | Debuffs applied by a boss (raid/dungeon encounter) | `ShowBossEnemy` | boss-applied auras | |
 | Priority | Debuffs Blizzard flags as high priority | `ShowPriority` | Blizzard's "high priority" classification | a general UI-sort flag, distinct from Blizzard/IMPORTANT above (which is nameplate-curation-specific) |
-| Dispellable | Debuffs you can dispel/cleanse | `ShowDispellableEnemy` | `DISPELLABLE` token | separate setting from the Friendly Debuffs Dispellable toggle — changing one doesn't affect the other |
-| Curse / Disease / Magic / Poison | Debuffs of the checked dispel type(s) | `FilterByTypeEnemy[1..4]` | `candidateFilters.includeDispelTypes = {...}` | the other toggles above exclude these checked dispel types from themselves (`excludeDispelTypes`), so a matching aura only shows once, via this group (fixed 2026-08-15 — previously duplicated) |
+| Dispellable | Debuffs you can dispel/cleanse, restricted to the dispel types checked below | `ShowDispellableEnemy` | `DISPELLABLE` token | separate setting from the Friendly Debuffs Dispellable toggle — changing one doesn't affect the other |
+| Curse / Disease / Magic / Poison | Dispellable debuffs of the checked dispel type(s) (optionally further restricted to Mine, see below) | `FilterByTypeEnemy[1..4]` | `candidateFilters.includeDispelTypes = {...}` | **combined with Dispellable (2026-08-15)**, not independent — grayed out and inert unless Dispellable is also checked; the other toggles above exclude these checked dispel types from themselves (`excludeDispelTypes`) whenever active, so a matching aura only shows once, via this group; defaults to all four checked |
 | Max Duration | Hides debuffs whose total duration exceeds the set number of seconds (0 = off) | `MaxDuration` (seconds, 0 = off) | duration cap | applies on top of whichever toggle(s) above are active; any non-zero value also hides permanent (duration-less) debuffs |
 
-Dispel Type is **intentionally independent** of the Dispellable toggle (matches the non-Midnight
-widget's behavior) — it is not gated behind Dispellable being enabled.
+Dispel Type was **intentionally independent** of the Dispellable toggle until 2026-08-15 (matched the
+non-Midnight widget's behavior at the time); both were changed together so it's now gated behind
+Dispellable being enabled instead — see the table row above. Mine is also folded into the Dispellable +
+Dispel Type group when both are active, so e.g. Mine + Dispellable + Curse shows only *your own*
+dispellable Curse debuffs, not everyone's.
 
-**Combinations**: 6 independent toggles (Mine/Blizzard/Boss/Priority/Dispellable/Dispel Type) means 64
-possible on/off combinations — too many to usefully enumerate. The rule is always the same though:
-**shown = union of every checked toggle's own set** (each row's "Shows" column above), and an aura
-matching several checked toggles at once still only renders once. Max Duration is not part of this
-union — it's a cap applied afterward, on top of whatever the union above produced. A few examples:
+**Combinations**: 5 independent toggles (Mine/Blizzard/Boss/Priority/Dispellable, with Dispel Type
+folded into Dispellable) means 32 possible on/off combinations — too many to usefully enumerate. The
+rule is always the same though: **shown = union of every checked toggle's own set** (each row's "Shows"
+column above), and an aura matching several checked toggles at once still only renders once. Max
+Duration is not part of this union — it's a cap applied afterward, on top of whatever the union above
+produced. A few examples:
 
 | Active toggles | Shown |
 | --- | --- |
 | All | Everything (Max Duration ignored too — All is a full short-circuit) |
 | (none) | Nothing |
 | Mine | Only debuffs you (or your pet) applied |
-| Boss + Curse | Boss debuffs ∪ Curse debuffs (a Curse debuff from a boss still only shows once) |
-| Blizzard + Priority + Dispellable | Union of all three |
+| Boss | Boss-applied debuffs only |
+| Dispellable + Curse | Dispellable Curse debuffs from anyone |
+| Mine + Dispellable + Curse | Dispellable Curse debuffs from you only |
+| Blizzard + Priority + Dispellable + (all 4 dispel types checked) | Union of Blizzard's set, Priority's set, and every dispellable debuff regardless of type |
 | Mine + Max Duration = 10 | Only your debuffs, further hidden if their total duration exceeds 10s |
 
 ## CrowdControl — Friendly

--- a/Source/Wiki/AurasFilterCriteria.md
+++ b/Source/Wiki/AurasFilterCriteria.md
@@ -1,0 +1,188 @@
+# Auras Widget — Filter Criteria Reference (Midnight / Patch 12.1.0)
+
+**Date:** 2026-08-15
+**Branch:** `hotfix/aura-12.1`
+**Applies to:** `Widgets/AurasWidgetMidnight.lua` (the Auras widget on WoW Midnight / Patch 12.1.0
+clients, built on Blizzard's `AuraContainer`/`AuraButton` API)
+
+---
+
+## Background
+
+On Midnight, the Auras widget no longer scans auras in Lua — it hands a declarative filter to
+Blizzard's `AuraContainer`, which does the scanning itself (aura data can be a *secret value* on this
+client and is not readable by addon code). Each Options toggle below maps to either:
+
+- an **`AuraFilters` filter-string token** (e.g. `PLAYER`, `DISPELLABLE`, `IMPORTANT`), or
+- a **`candidateFilters` field** (e.g. `isBossAura`, `maxDuration`), a separate, more granular
+  restriction Blizzard added in Patch 12.1.0.
+
+All filter strings additionally always carry the aura type (`HELPFUL` for Buffs, `HARMFUL` for
+Debuffs/CrowdControl) and `INCLUDE_NAME_PLATE_ONLY` (without this token, auras Blizzard flags as
+nameplate-only are silently excluded — not repeated per row below).
+
+Where a row says "**not implemented**", the Options toggle exists and is clickable but currently has
+no effect on Midnight — a known gap, not a setting you're misusing.
+
+---
+
+## Buffs — Friendly
+
+**All**/**All on NPCs** short-circuit into a single unrestricted group (like everywhere else "All"
+appears); otherwise Mine/Player Can Apply/Big Defensives are independent, **freely-combinable**
+OR-conditions via one `AddAuraGroup` each, cross-excluding each other so a multi-matching aura isn't
+shown twice. "All on NPCs" itself can't be freely combined with the other three the same way — it's
+conceptually "All, but scoped to NPCs", not a peer condition (no `candidateFilters` field exists for
+"unit is an NPC" to cross-exclude it with) — so it stays a short-circuit alongside "All".
+
+| Options toggle | Shows | DB field | Technical | Note |
+| --- | --- | --- | --- | --- |
+| Show Buffs | — | `ShowFriendly` | group master switch | not a filter itself, gates the whole aura type |
+| All | Every buff on friendly units | `ShowAllFriendly` | no restriction beyond `HELPFUL` | |
+| All on NPCs | Every buff, but only on friendly NPCs (not friendly players) | `ShowOnFriendlyNPCs` | no restriction, **only when the unit is an NPC** | checked on the addon side, since no `AuraFilters` token for "unit is an NPC" exists; short-circuits like All (see above) |
+| Mine | Buffs that you (or your pet) cast | `ShowOnlyMine` | `PLAYER` token | |
+| Player Can Apply | Buffs you could apply yourself, regardless of who actually cast them | `ShowPlayerCanApply` | `candidateFilters.canApplyAura = true` | |
+| Big Defensives | Buffs Blizzard classifies as big defensive cooldowns | `ShowFriendlyBigDefensives` | `BIG_DEFENSIVE` token | |
+
+**Combinations** ("–" = doesn't matter):
+
+| All | All on NPCs | Mine | Can Apply | Big Def. | Shown on NPCs | Shown on players |
+| --- | --- | --- | --- | --- | --- | --- |
+| ✅ | – | – | – | – | Everything | Everything |
+| ❌ | ✅ | ❌ | ❌ | ❌ | Everything | Nothing |
+| ❌ | ✅ | ✅ | – | – | Everything (NPCs wins) | Mine only |
+| ❌ | ✅ | – | ✅ | – | Everything (NPCs wins) | Can Apply only |
+| ❌ | ✅ | – | – | ✅ | Everything (NPCs wins) | Big Defensives only |
+| ❌ | ✅ | ✅ | ✅ | ✅ | Everything (NPCs wins) | Union of all three |
+| ❌ | ❌ | ✅ | ❌ | ❌ | Mine only | same |
+| ❌ | ❌ | ❌ | ✅ | ❌ | Can Apply only | same |
+| ❌ | ❌ | ❌ | ❌ | ✅ | Big Defensives only | same |
+| ❌ | ❌ | ✅ | ✅ | ❌ | Mine ∪ Can Apply | same |
+| ❌ | ❌ | ✅ | ❌ | ✅ | Mine ∪ Big Defensives | same |
+| ❌ | ❌ | ❌ | ✅ | ✅ | Can Apply ∪ Big Defensives | same |
+| ❌ | ❌ | ✅ | ✅ | ✅ | Union of all three | same |
+| ❌ | ❌ | ❌ | ❌ | ❌ | Nothing | Nothing |
+
+"All on NPCs" only ever affects NPC targets — on players it has no effect regardless of whether it's
+checked, and the union of Mine/Can Apply/Big Defensives applies the same way on both target types.
+
+## Buffs — Enemy
+
+Same pattern as Friendly above: All/All on NPCs short-circuit; Dispellable/Magic are independent,
+freely-combinable OR-conditions.
+
+| Options toggle | Shows | DB field | Technical | Note |
+| --- | --- | --- | --- | --- |
+| Show Buffs | — | `ShowEnemy` | group master switch | |
+| All | Every buff on enemy units | `ShowAllEnemy` | no restriction beyond `HELPFUL` | |
+| All on NPCs | Every buff, but only on enemy NPCs (not enemy players) | `ShowOnEnemyNPCs` | no restriction, **only when the unit is an NPC** | checked on the addon side; short-circuits like All |
+| Dispellable | Buffs you can dispel/purge/steal | `ShowDispellable` | `DISPELLABLE` token | Patch 12.1.0 token — dispellable by anyone, broader than the older "a raid member's kit can dispel this specifically" token |
+| Magic | Buffs of dispel type Magic | `ShowMagic` | `candidateFilters.includeDispelTypes = { Magic = true }` | |
+
+**Combinations**:
+
+| All | All on NPCs | Dispellable | Magic | Shown on NPCs | Shown on players |
+| --- | --- | --- | --- | --- | --- |
+| ✅ | – | – | – | Everything | Everything |
+| ❌ | ✅ | ❌ | ❌ | Everything | Nothing |
+| ❌ | ✅ | ✅ | – | Everything (NPCs wins) | Dispellable only |
+| ❌ | ✅ | – | ✅ | Everything (NPCs wins) | Magic only |
+| ❌ | ✅ | ✅ | ✅ | Everything (NPCs wins) | Dispellable ∪ Magic |
+| ❌ | ❌ | ✅ | ❌ | Dispellable only | same |
+| ❌ | ❌ | ❌ | ✅ | Magic only | same |
+| ❌ | ❌ | ✅ | ✅ | Dispellable ∪ Magic | same |
+| ❌ | ❌ | ❌ | ❌ | Nothing | Nothing |
+
+## Debuffs — Friendly
+
+Same freely-combinable multi-group pattern as Debuffs — Enemy below (fewer toggles: no Mine/Blizzard/
+Priority/Max Duration equivalent exposed for friendly): **All** short-circuits everything into a single
+unrestricted group; otherwise Dispellable/Boss/dispel-type are each their own `AddAuraGroup`, cross-
+excluding each other so a multi-matching aura isn't shown twice.
+
+| Options toggle | Shows | DB field | Technical | Note |
+| --- | --- | --- | --- | --- |
+| Show Debuffs | — | `ShowFriendly` | group master switch | |
+| All | Every debuff on friendly units (except crowd control, which has its own grid) | `ShowAllFriendly` | Crowd Control excluded (own grid) | |
+| Dispellable | Debuffs you can dispel/cleanse | `ShowDispellable` | `DISPELLABLE` token, CC excluded | |
+| Boss | Debuffs applied by a boss (raid/dungeon encounter) | `ShowBoss` | `candidateFilters.isBossAura = true` | separate DB field from Enemy's `ShowBossEnemy` — changing one doesn't affect the other |
+| Curse / Disease / Magic / Poison | Debuffs of the checked dispel type(s) | `FilterByType[1..4]` | `candidateFilters.includeDispelTypes = {...}` | separate DB field from Enemy's `FilterByTypeEnemy[1..4]`; Dispellable/Boss exclude these checked dispel types from themselves (`excludeDispelTypes`), so a matching aura only shows once, via this group |
+
+**Combinations** (Dispel Type = at least one of Curse/Disease/Magic/Poison checked; which specific
+type(s) narrows the result further but doesn't change the combination logic):
+
+| All | Dispellable | Boss | Dispel Type | Shown |
+| --- | --- | --- | --- | --- |
+| ✅ | – | – | – | Everything (CC excluded) |
+| ❌ | ✅ | ❌ | ❌ | Dispellable only |
+| ❌ | ❌ | ✅ | ❌ | Boss only |
+| ❌ | ❌ | ❌ | ✅ | Checked dispel type(s) only |
+| ❌ | ✅ | ✅ | ❌ | Dispellable ∪ Boss |
+| ❌ | ✅ | ❌ | ✅ | Dispellable ∪ Dispel Type |
+| ❌ | ❌ | ✅ | ✅ | Boss ∪ Dispel Type |
+| ❌ | ✅ | ✅ | ✅ | Union of all three |
+| ❌ | ❌ | ❌ | ❌ | Nothing |
+
+## Debuffs — Enemy
+
+The richest filter set, and the only one where toggles are **freely combinable** rather than mutually
+exclusive: **All** short-circuits everything into a single unrestricted group; otherwise, every toggle
+below is evaluated independently and an aura matching several toggles is still only shown once (never
+duplicated).
+
+| Options toggle | Shows | DB field | Technical | Note |
+| --- | --- | --- | --- | --- |
+| Mine | Debuffs that you (or your pet) applied | `ShowOnlyMine` | applied by you or your pet | |
+| Blizzard | Debuffs Blizzard itself would show on its own default nameplates | `ShowBlizzardForEnemy` | `IMPORTANT` token | shown on Blizzard's own default nameplates |
+| Boss | Debuffs applied by a boss (raid/dungeon encounter) | `ShowBossEnemy` | boss-applied auras | |
+| Priority | Debuffs Blizzard flags as high priority | `ShowPriority` | Blizzard's "high priority" classification | a general UI-sort flag, distinct from Blizzard/IMPORTANT above (which is nameplate-curation-specific) |
+| Dispellable | Debuffs you can dispel/cleanse | `ShowDispellableEnemy` | `DISPELLABLE` token | separate setting from the Friendly Debuffs Dispellable toggle — changing one doesn't affect the other |
+| Curse / Disease / Magic / Poison | Debuffs of the checked dispel type(s) | `FilterByTypeEnemy[1..4]` | `candidateFilters.includeDispelTypes = {...}` | the other toggles above exclude these checked dispel types from themselves (`excludeDispelTypes`), so a matching aura only shows once, via this group (fixed 2026-08-15 — previously duplicated) |
+| Max Duration | Hides debuffs whose total duration exceeds the set number of seconds (0 = off) | `MaxDuration` (seconds, 0 = off) | duration cap | applies on top of whichever toggle(s) above are active; any non-zero value also hides permanent (duration-less) debuffs |
+
+Dispel Type is **intentionally independent** of the Dispellable toggle (matches the non-Midnight
+widget's behavior) — it is not gated behind Dispellable being enabled.
+
+**Combinations**: 6 independent toggles (Mine/Blizzard/Boss/Priority/Dispellable/Dispel Type) means 64
+possible on/off combinations — too many to usefully enumerate. The rule is always the same though:
+**shown = union of every checked toggle's own set** (each row's "Shows" column above), and an aura
+matching several checked toggles at once still only renders once. Max Duration is not part of this
+union — it's a cap applied afterward, on top of whatever the union above produced. A few examples:
+
+| Active toggles | Shown |
+| --- | --- |
+| All | Everything (Max Duration ignored too — All is a full short-circuit) |
+| (none) | Nothing |
+| Mine | Only debuffs you (or your pet) applied |
+| Boss + Curse | Boss debuffs ∪ Curse debuffs (a Curse debuff from a boss still only shows once) |
+| Blizzard + Priority + Dispellable | Union of all three |
+| Mine + Max Duration = 10 | Only your debuffs, further hidden if their total duration exceeds 10s |
+
+## CrowdControl — Friendly
+
+| Options toggle | Shows | DB field | Technical | Note |
+| --- | --- | --- | --- | --- |
+| Show Crowd Control | — | `ShowFriendly` | group master switch | |
+| All | Every crowd-control effect (stun, fear, root, ...) on friendly units | `ShowAllFriendly` | Crowd Control auras | |
+| Dispellable | Crowd-control effects you can dispel/cleanse | `ShowDispellable` | `DISPELLABLE` token | fixed 2026-08-15, previously silently ignored |
+
+Not multi-group — a plain `elseif` (still mutually exclusive, unlike Buffs/Debuffs above):
+
+| All | Dispellable | Shown |
+| --- | --- | --- |
+| ✅ | ❌ | Every CC effect |
+| ❌ | ✅ | Only dispellable CC effects |
+| ❌ | ❌ | Nothing |
+
+## CrowdControl — Enemy
+
+| Options toggle | Shows | DB field | Technical | Note |
+| --- | --- | --- | --- | --- |
+| Show Crowd Control | — | `ShowEnemy` | group master switch | |
+| All | Every crowd-control effect (stun, fear, root, ...) on enemy units | `ShowAllEnemy` | Crowd Control auras | |
+
+Only one toggle exists here (no Dispellable equivalent in the Enemy Midnight panel) — either every CC
+effect shows (All on) or none do (All off), no combinations possible.
+
+Friendly and Enemy Crowd Control currently use the identical underlying filter once enabled — only
+whether the group is shown at all differs per reaction.

--- a/Source/Wiki/AurasFilterCriteria.md
+++ b/Source/Wiki/AurasFilterCriteria.md
@@ -1,7 +1,5 @@
 # Auras Widget — Filter Criteria Reference (Midnight / Patch 12.1.0)
 
-**Date:** 2026-08-15
-**Branch:** `hotfix/aura-12.1`
 **Applies to:** `Widgets/AurasWidgetMidnight.lua` (the Auras widget on WoW Midnight / Patch 12.1.0
 clients, built on Blizzard's `AuraContainer`/`AuraButton` API)
 
@@ -11,11 +9,12 @@ clients, built on Blizzard's `AuraContainer`/`AuraButton` API)
 
 On Midnight, the Auras widget no longer scans auras in Lua — it hands a declarative filter to
 Blizzard's `AuraContainer`, which does the scanning itself (aura data can be a *secret value* on this
-client and is not readable by addon code). Each Options toggle below maps to either:
-
-- an **`AuraFilters` filter-string token** (e.g. `PLAYER`, `DISPELLABLE`, `IMPORTANT`), or
-- a **`candidateFilters` field** (e.g. `isBossAura`, `maxDuration`), a separate, more granular
-  restriction Blizzard added in Patch 12.1.0.
+client and is not readable by addon code). Each Options toggle below maps to either an **`AuraFilters`
+filter-string token** (e.g. `PLAYER`, `DISPELLABLE`, `IMPORTANT`) or a **`candidateFilters` field**
+(e.g. `isBossAura`, `maxDuration`), a separate, more granular restriction Blizzard added in Patch
+12.1.0. For how the widget is built (pooling, the multi-group combination algorithm, API quirks and
+gotchas discovered along the way), see [`AurasWidgetImplementation.md`](AurasWidgetImplementation.md)
+instead — this page only covers what each toggle *does*.
 
 All filter strings additionally always carry the aura type (`HELPFUL` for Buffs, `HARMFUL` for
 Debuffs/CrowdControl) and `INCLUDE_NAME_PLATE_ONLY` (without this token, auras Blizzard flags as
@@ -43,8 +42,9 @@ conceptually "All, but scoped to NPCs", not a peer condition (no `candidateFilte
 | Mine | Buffs that you (or your pet) cast | `ShowOnlyMine` | `PLAYER` token | |
 | Player Can Apply | Buffs you could apply yourself, regardless of who actually cast them | `ShowPlayerCanApply` | `candidateFilters.canApplyAura = true` | |
 | Big Defensives | Buffs Blizzard classifies as big defensive cooldowns | `ShowFriendlyBigDefensives` | `BIG_DEFENSIVE` token | |
+| Max Duration | Hides buffs whose total duration exceeds the set number of seconds (0 = off) | `MaxDurationFriendly` (seconds, 0 = off) | `candidateFilters.maxDuration` | applies on top of whichever toggle(s) above are active, including All; any non-zero value also hides permanent (duration-less) buffs — useful for filtering out passive self-buffs (flasks, food, Well Fed, ...); moved here from Debuffs (2026-08-16), where a duration cap made less sense |
 
-**Combinations** ("–" = doesn't matter):
+**Combinations** ("–" = doesn't matter, Max Duration omitted — it's a cap applied after the union, not part of it):
 
 | All | All on NPCs | Mine | Can Apply | Big Def. | Shown on NPCs | Shown on players |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -78,8 +78,9 @@ freely-combinable OR-conditions.
 | All on NPCs | Every buff, but only on enemy NPCs (not enemy players) | `ShowOnEnemyNPCs` | no restriction, **only when the unit is an NPC** | checked on the addon side; short-circuits like All |
 | Dispellable | Buffs you can dispel/purge/steal | `ShowDispellable` | `DISPELLABLE` token | Patch 12.1.0 token — dispellable by anyone, broader than the older "a raid member's kit can dispel this specifically" token |
 | Magic | Buffs of dispel type Magic | `ShowMagic` | `candidateFilters.includeDispelTypes = { Magic = true }` | |
+| Max Duration | Hides buffs whose total duration exceeds the set number of seconds (0 = off) | `MaxDurationEnemy` (seconds, 0 = off) | `candidateFilters.maxDuration` | separate setting from the Friendly Buffs Max Duration above — changing one doesn't affect the other; applies on top of whichever toggle(s) above are active, including All |
 
-**Combinations**:
+**Combinations** (Max Duration omitted — it's a cap applied after the union, not part of it):
 
 | All | All on NPCs | Dispellable | Magic | Shown on NPCs | Shown on players |
 | --- | --- | --- | --- | --- | --- |
@@ -96,7 +97,7 @@ freely-combinable OR-conditions.
 ## Debuffs — Friendly
 
 Same freely-combinable multi-group pattern as Debuffs — Enemy below (fewer toggles: no Mine/Blizzard/
-Priority/Max Duration equivalent exposed for friendly): **All** short-circuits everything into a single
+Priority equivalent exposed for friendly): **All** short-circuits everything into a single
 unrestricted group; otherwise Dispellable/Boss/dispel-type are each their own `AddAuraGroup`, cross-
 excluding each other so a multi-matching aura isn't shown twice. **Exception**: Dispellable and Dispel
 Type are combined, not independent — see below.
@@ -130,13 +131,15 @@ duplicated).
 
 | Options toggle | Shows | DB field | Technical | Note |
 | --- | --- | --- | --- | --- |
-| Mine | Debuffs that you (or your pet) applied | `ShowOnlyMine` | applied by you or your pet | |
-| Blizzard | Debuffs Blizzard itself would show on its own default nameplates | `ShowBlizzardForEnemy` | `IMPORTANT` token | shown on Blizzard's own default nameplates |
-| Boss | Debuffs applied by a boss (raid/dungeon encounter) | `ShowBossEnemy` | boss-applied auras | |
-| Priority | Debuffs Blizzard flags as high priority | `ShowPriority` | Blizzard's "high priority" classification | a general UI-sort flag, distinct from Blizzard/IMPORTANT above (which is nameplate-curation-specific) |
+| Mine | Debuffs that you (or your pet) applied | `ShowOnlyMine` | `PLAYER` token | |
+| Blizzard | Debuffs **you applied** that Blizzard itself would also show on its own default nameplates | `ShowBlizzardForEnemy` | `PLAYER` token + (`candidateFilters.nameplateShowAll = true` **or** `nameplateShowPersonal = true`), two peer groups | not the `IMPORTANT` token — that only ever applies to helpful auras per its own doc comment, so combined with `HARMFUL` it matches nothing. Two separate Blizzard curation flags exist: `nameplateShowAll` (shown for anyone) and `nameplateShowPersonal` (shown only when self-applied, which is why it needs the `PLAYER` restriction to make sense) — both map to real `candidateFilters` fields, matching the legacy widget's `aura.nameplateShowAll or (aura.nameplateShowPersonal and aura.CastByPlayer)`. `PLAYER` is hardcoded by deliberate design (2026-08-16) — "Blizzard" always means "mine, and Blizzard-flagged", not "anyone's Blizzard-flagged debuffs" (checking Mine+Blizzard together can't narrow it further, since Mine's own set is already the superset) — see `AurasWidgetImplementation.md` |
+| Boss | Debuffs applied by a boss (raid/dungeon encounter) | `ShowBossEnemy` | `candidateFilters.isBossAura = true` | |
+| Priority | Debuffs Blizzard flags as high priority | `ShowPriority` | `candidateFilters.isPriorityAura = true` | a general UI-sort flag, distinct from Blizzard above (which is nameplate-curation-specific) |
 | Dispellable | Debuffs you can dispel/cleanse, restricted to the dispel types checked below | `ShowDispellableEnemy` | `DISPELLABLE` token | separate setting from the Friendly Debuffs Dispellable toggle — changing one doesn't affect the other |
 | Curse / Disease / Magic / Poison | Dispellable debuffs of the checked dispel type(s) (optionally further restricted to Mine, see below) | `FilterByTypeEnemy[1..4]` | `candidateFilters.includeDispelTypes = {...}` | **combined with Dispellable (2026-08-15)**, not independent — grayed out and inert unless Dispellable is also checked; the other toggles above exclude these checked dispel types from themselves (`excludeDispelTypes`) whenever active, so a matching aura only shows once, via this group; defaults to all four checked |
-| Max Duration | Hides debuffs whose total duration exceeds the set number of seconds (0 = off) | `MaxDuration` (seconds, 0 = off) | duration cap | applies on top of whichever toggle(s) above are active; any non-zero value also hides permanent (duration-less) debuffs |
+
+No Max Duration here — moved to Buffs (2026-08-16), where a duration cap makes more practical sense
+(filtering out passive self-buffs) than for Debuffs.
 
 Dispel Type was **intentionally independent** of the Dispellable toggle until 2026-08-15 (matched the
 non-Midnight widget's behavior at the time); both were changed together so it's now gated behind
@@ -147,20 +150,18 @@ dispellable Curse debuffs, not everyone's.
 **Combinations**: 5 independent toggles (Mine/Blizzard/Boss/Priority/Dispellable, with Dispel Type
 folded into Dispellable) means 32 possible on/off combinations — too many to usefully enumerate. The
 rule is always the same though: **shown = union of every checked toggle's own set** (each row's "Shows"
-column above), and an aura matching several checked toggles at once still only renders once. Max
-Duration is not part of this union — it's a cap applied afterward, on top of whatever the union above
-produced. A few examples:
+column above), and an aura matching several checked toggles at once still only renders once. A few
+examples:
 
 | Active toggles | Shown |
 | --- | --- |
-| All | Everything (Max Duration ignored too — All is a full short-circuit) |
+| All | Everything (All is a full short-circuit) |
 | (none) | Nothing |
 | Mine | Only debuffs you (or your pet) applied |
 | Boss | Boss-applied debuffs only |
 | Dispellable + Curse | Dispellable Curse debuffs from anyone |
 | Mine + Dispellable + Curse | Dispellable Curse debuffs from you only |
-| Blizzard + Priority + Dispellable + (all 4 dispel types checked) | Union of Blizzard's set, Priority's set, and every dispellable debuff regardless of type |
-| Mine + Max Duration = 10 | Only your debuffs, further hidden if their total duration exceeds 10s |
+| Blizzard + Priority + Dispellable + (all 4 dispel types checked) | Union of your own Blizzard-flagged debuffs, Priority's set, and every dispellable debuff regardless of type |
 
 ## CrowdControl — Friendly
 

--- a/Source/Wiki/AurasWidgetImplementation.md
+++ b/Source/Wiki/AurasWidgetImplementation.md
@@ -222,6 +222,14 @@ and/or in-game testing. Worth knowing before touching this code.
   `customDispelColorCurve` (a `C_CurveUtil` color curve) is the alternative Blizzard also supports,
   but needs a curve object; `customDispelColorMap` is functionally equivalent for this use case and
   needs no such object.
+- **`customDispelColorMap`'s lookup key for an aura with no dispel type is the literal string
+  `"None"`** (`Blizzard_CustomAuraButton.lua`'s `GetDispelTypeMapKey`: `auraData.dispelName or
+  "None"`) - not documented anywhere obvious, found by reading the source. This is what makes
+  `AuraWidget.DefaultBuffColor`/`DefaultDebuffColor` (Options: Appearance → Highlight → Buff/Debuff
+  Color) work at all: `GetDispelTypeColorMapForAuraType` adds a `"None"` entry to a per-aura_type copy
+  of `DISPEL_TYPE_COLOR_MAP`, and `showWithoutDispelType = true` on `AddDispelTypeTexture` makes the
+  border draw for every aura instead of only dispel-typed ones - matching the legacy widget's
+  `Widget:GetColorForAura`, which likewise colors every aura, not just dispel-typed ones.
 
 ---
 
@@ -241,6 +249,8 @@ capability doesn't exist for addon code on `AuraButton`/`AuraContainer` as of Pa
 | Per-spell whitelist/blacklist | hidden (Options) | `candidateFilters.includeSpellIDs`/`excludeSpellIDs`, reaction-restricted (§6) | **Yes, partially** |
 | "Dispellable (only me)" for Enemy Debuffs | not implemented | no Blizzard token/candidateFilters field for player-personal dispel capability exists — would need a static class/spec→dispel-type lookup table instead | **Yes, via workaround** |
 | Dynamic sibling-height anchoring (no wasted vertical gap above an empty grid) | not implemented (static max-height used instead) | none found — `GetAuraGroupFrameCount` is pool size not live count (§6), no `GetHeight` on Forbidden containers | **No**, not with a currently-known API |
+| `CenterAuras` | inert, not gated | pure Lua-side layout math (center the flow-layout group instead of growing from the alignment corner) — not an API blocker, just not wired into `UpdateAuraContainer`'s layout code | **Yes** — not built yet |
+| `ModeIcon.ShowBorder` (generic icon border, independent of dispel-type coloring) | inert, only reachable via Options when Icon Style = Custom | none found for a plain non-dispel-type border texture beyond what `InitializeAuraButton` already draws | **Yes** — a plain `CreateTexture` border, same mechanism as the dispel-type border, just unconditional |
 
 ---
 

--- a/Source/Wiki/AurasWidgetImplementation.md
+++ b/Source/Wiki/AurasWidgetImplementation.md
@@ -1,0 +1,252 @@
+# Auras Widget — Implementation Reference (Midnight / Patch 12.1.0)
+
+**Applies to:** `Widgets/AurasWidgetMidnight.lua` (the Auras widget on WoW Midnight / Patch 12.1.0
+clients only — the non-Midnight/Classic widget, `Widgets/AurasWidget.lua`, uses the older
+`AuraUtil.ForEachAura`/`C_UnitAuras` pull-based scanning and is out of scope here)
+
+This page documents **how** the widget is built — which Blizzard API implements which piece of
+behavior, and the API quirks/limitations relevant to it. For **what each Options toggle does**
+(user-facing filter behavior, combination tables), see
+[`AurasFilterCriteria.md`](AurasFilterCriteria.md) instead — the two pages are deliberately
+non-overlapping.
+
+---
+
+## 1. Why `AuraContainer`/`AuraButton`
+
+Aura data can be a *secret value* on Midnight and is not readable by addon-side Lua code
+(`C_UnitAuras.GetUnitAuras`/`GetAuraSlots` can throw or return empty for nameplate unit tokens). The
+`AuraContainer`/`AuraButton` intrinsic frame types sidestep this entirely: Blizzard's engine owns
+aura fetching, filtering, and updating internally once an addon calls `container:SetUnit(unitToken)`
+— no addon-side Lua access to aura data is needed at all. `SecureAuraHeaderTemplate` has been removed
+from Mainline in favor of this; it's Blizzard's intended direction, not an optional extra.
+
+This is the widget's only aura display path — there is no addon-side scanning fallback.
+`HasAuraContainers` (feature-detected via
+`C_XMLUtil.GetTemplateInfo("CustomAuraContainerTemplate")`, since there's no dedicated
+expansion-level flag for this) is kept only as a defensive guard.
+
+---
+
+## 2. Core API surface used — Layout & Appearance
+
+Filter-composition API (`AddAuraGroup`'s `filterString`, `candidateFilters`,
+`SetAuraGroupFilterString`/`CandidateFilters`, `SetUnit`, `SetEnabled`) is covered by §3/§4 and
+`AurasFilterCriteria.md` instead — this table only covers what shapes how auras are laid out and how
+each icon looks.
+
+| API |
+| --- |
+| **`container:SetAuraGroupLayout(groupKey, { elementWidth, elementHeight, elementSpacing, lineSpacing })`**<br>Per-group flow-layout sizing/spacing hints. |
+| **`container:SetFlowLayoutAnchorPoint/GrowthDirection/MaximumLineSize(...)`**<br>Container-wide grid layout: anchor corner, growth direction, wrap width. |
+| **`container:SetAuraGroupMaxFrameCount(groupKey, n)`**<br>Caps how many auras a group displays; `0` disables the group entirely. |
+| **`options.initializeFrame`** (passed to `AddAuraGroup`)<br>Callback that configures each `AuraButton` **once**, the first time Blizzard's internal frame pool creates it — not on reuse. See the create-time-only gotcha in §6. |
+| **`AuraButton:SetIcon/SetDurationCooldown/SetDurationText/SetApplicationCount/AddDispelTypeTexture/SetMouseMotionEnabled/SetHideTooltipInCombat`**<br>Fixed, allow-listed `Set*` surface for configuring a button's appearance — no generic `SetScript`/event access. |
+| **`PixelUtil.SetSize(auraButton, w, h)`**<br>Icon size — a plain frame-layout setter, not aura-data-specific, so it's callable despite `AuraButton`'s Forbidden Aspects. |
+| **`container:GetAuraGroupFrame(groupKey, index)` / `GetAuraGroupFrameCount(groupKey)`**<br>Enumerate already-created `AuraButton`s in a group, to reapply appearance settings after the fact. See the pool-size gotcha in §6. |
+
+`AuraContainer`s **cannot be created during combat**. Since TidyPlates creates widget frames lazily
+the first time Blizzard hands out a nameplate (which can happen mid-pull), containers are
+**pre-allocated in a pool** out of combat instead (`PreallocateAuraContainers`, called from
+`Widget:OnEnable` and retried from `Widget:PLAYER_REGEN_ENABLED`/`DISABLED`; pool size `40` per aura
+type) and claimed per-plate on demand (`AcquireAuraContainer`, called from `Widget:Create`) rather
+than created lazily like the rest of this widget's frames.
+
+---
+
+## 3. Code map — concept → function → API
+
+| Concept | Function(s) | API used |
+| --- | --- | --- |
+| Container pooling / pre-allocation | `PreallocateAuraContainers`, `AcquireAuraContainer`, `CreateAuraContainer` | `CreateFrame("AuraContainer", ...)`, `AddAuraGroup` |
+| Per-toggle → filter composition | `GetFriendlyBuffsGroupConfigs`, `GetEnemyBuffsGroupConfigs`, `GetFriendlyDebuffsGroupConfigs`, `GetEnemyDebuffsGroupConfigs`, `GetCrowdControlFilterString` | build `filterString`/`candidateFilters` per group |
+| Multi-toggle free combination + no-double-render guarantee | `BuildGroupConfigsFromConditions` | ordered cross-exclusion across groups (see §4) |
+| Per-button visuals (icon, cooldown swipe, stack count, duration text, dispel-type border, tooltip) | `InitializeAuraButton` | `SetIcon`/`SetDurationCooldown`/`SetDurationText`/`SetApplicationCount`/`AddDispelTypeTexture`/`SetMouseMotionEnabled`/`PixelUtil.SetSize` |
+| Live-reapplying icon size/tooltip/cooldown-spiral to already-created buttons | `ReapplyLiveAuraButtonSettings` | `GetAuraGroupFrame`/`GetAuraGroupFrameCount` + same `Set*` calls, deferred via `Addon.ExecuteAfterCombatEnds` |
+| Sort order mapping | `GetSortMethod`, `GetSortDirection` | `AuraContainerSortMethod`/`AuraContainerSortDirection` enums |
+| Grid layout / anchoring | `Widget:UpdateAuraContainer`, `GetFlowLayoutForAlignment` | `SetFlowLayoutAnchorPoint`/`GrowthDirection`/`MaximumLineSize`, `SetAuraGroupLayout`; addon's own `AnchorFrameTo` for positioning relative to the healthbar/sibling grid |
+| Dispel-type border coloring | `InitializeAuraButton`, `BuildDispelTypeColorMap` | `AddDispelTypeTexture(texture, { style = Border, customDispelColorMap, ... })` |
+| Per-plate update entry points | `Widget:OnUnitAdded` → `Widget:UpdateAuras` → `Widget:UpdateAurasGrids` → `Widget:UpdateAuraContainer` (×3, one per aura type) | — |
+
+---
+
+## 4. `BuildGroupConfigsFromConditions` — the multi-group combination algorithm
+
+Buffs and Debuffs (both reactions) support independent, freely-combinable OR-conditions: each active
+Options toggle becomes its own `AddAuraGroup`. An aura matching two simultaneously-active toggles
+must render via exactly one group, never zero or two. `BuildGroupConfigsFromConditions` guarantees
+this:
+
+- Each condition, in the order its caller pushed it into the `conditions` list, gets every
+  **earlier** condition's tokens negated (`!token`) and boolean `candidateFilters` fields forced
+  `false` into its own filter — so a double-matching aura only ever satisfies the *first* group it
+  matches, never a later one.
+- Exclusion is **ordered, not symmetric**: each condition excludes only the conditions listed
+  *before* it, never the ones after. Symmetric exclusion (every group excluding every other active
+  condition from itself) would make a double-matching aura fail *both* groups' restrictions and
+  vanish entirely. Ordered exclusion instead guarantees every aura shows via exactly one group: the
+  earliest-listed condition it satisfies. Which condition "wins" for a double match is an arbitrary
+  but deterministic tie-break (list order = push order in the calling `Get*GroupConfigs` function).
+- The `"dispeltype"` condition key is exempt from this exclusion loop: `candidateFilters.includeDispelTypes`
+  is a table, not a plain boolean/token, so it can't be negated the same way. Instead, every *other*
+  group gets `candidateFilters.excludeDispelTypes` set to the checked dispel types whenever a
+  `"dispeltype"` group exists, so the exclusion direction is reversed for that one case (everyone
+  else excludes it, instead of it excluding everyone before it).
+- `All`/`All on NPCs` toggles always short-circuit into a single unrestricted group instead of
+  joining the free combination — "All on NPCs" has no `candidateFilters` equivalent for "unit is an
+  NPC" to cross-exclude it with, so treating it as a peer condition would duplicate every other
+  active toggle's auras on NPC targets.
+
+`CrowdControl` (either reaction) is still single-condition only (`GetCrowdControlFilterString`, a
+plain `elseif`) — not converted to this pattern, since it only ever has one or two toggles to begin
+with.
+
+---
+
+## 5. Aura filtering — the `Get*GroupConfigs` functions
+
+Five functions turn today's Options settings into the `conditions` list `BuildGroupConfigsFromConditions`
+(§4) consumes, one per aura-type/reaction combination. Each returns a table keyed by group name →
+`{ filterString, candidateFilters }`; a group key from `AURA_GROUP_KEYS[aura_type]` missing from the
+result means "disable this group" (`Widget:UpdateAuraContainer` sets its `maxFrameCount` to `0`).
+
+- **`GetFriendlyBuffsGroupConfigs(db, unit)`** / **`GetEnemyBuffsGroupConfigs(db, unit)`** — `All`/
+  `All on NPCs` (`unit.type == "NPC"`, checked in Lua since no `candidateFilters` field exists for
+  "unit is an NPC") short-circuit into one unrestricted `"main"` group (also carrying `maxDuration`,
+  see below). Otherwise: Friendly pushes `"main"` (Mine, `PLAYER` token), `"canapply"` (Player Can
+  Apply, `candidateFilters.canApplyAura`), `"bigdefensive"` (Big Defensives, `BIG_DEFENSIVE` token);
+  Enemy pushes `"dispellable"` (`DISPELLABLE` token) and `"magic"`
+  (`candidateFilters.includeDispelTypes = { Magic = true }`). `MaxDurationFriendly` /
+  `MaxDurationEnemy` - separate fields per reaction, moved here from Debuffs on 2026-08-16 - is
+  stamped onto every resulting group's `candidateFilters.maxDuration` in a pass *after*
+  `BuildGroupConfigsFromConditions` returns, since it's an AND-restriction on top of whichever
+  OR-condition(s) ended up active (including `All`), not a condition/group of its own.
+- **`GetFriendlyDebuffsGroupConfigs(db)`** / **`GetEnemyDebuffsGroupConfigs(db)`** — `All` short-circuits
+  into one unrestricted `"main"` group. Otherwise, Boss (`"boss"`, `candidateFilters.isBossAura`) is always its
+  own condition; Enemy additionally pushes `"main"` (Mine, `PLAYER` token — see the
+  `isFromPlayerOrPlayerPet` gotcha in §6) and `"priority"` (`candidateFilters.isPriorityAura`).
+  Blizzard is two peer groups, not one: `"important"` (`PLAYER` token + `candidateFilters.nameplateShowAll`)
+  and `"importantpersonal"` (`PLAYER` token + `candidateFilters.nameplateShowPersonal`, with
+  `nameplateShowAll` explicitly forced `false` to avoid double-rendering an aura that happens to carry
+  both flags) — a single `AddAuraGroup` can't express "field A OR field B" since `candidateFilters`
+  entries are ANDed together, so the two Blizzard curation flags (matches the legacy widget's
+  `aura.nameplateShowAll or (aura.nameplateShowPersonal and aura.CastByPlayer)` — see the `IMPORTANT`
+  gotcha in §6) need two groups. `"importantpersonal"` is built by cloning `"important"`'s
+  already-fully-excluded result (same exclusions against Mine/Boss/Priority/dispeltype) rather than
+  pushed through `BuildGroupConfigsFromConditions` as its own condition — both would carry the
+  identical `PLAYER` token, and ordered exclusion would negate the earlier one's token into the later
+  one's filter string (`PLAYER|!PLAYER`, a self-contradiction matching nothing). Both are hardcoded to
+  always require `PLAYER`, not conditional on Mine, so "Blizzard" always means "my own Blizzard-
+  flagged debuffs" rather than "anyone's" — checking Mine alongside it can't narrow the result
+  further, since Mine's own group is already a superset.
+  Dispellable + Dispel Type are combined rather than independent conditions: a `"dispeltype"` group is
+  only ever pushed while Dispellable is checked, always carries the `DISPELLABLE` token plus
+  `candidateFilters.includeDispelTypes` for whichever Curse/Disease/Magic/Poison boxes are checked —
+  Enemy additionally adds the `PLAYER` token to this same group when Mine is also checked, so Mine +
+  Dispellable + a checked type combine into "only my dispellable auras of that type". No duration cap
+  exists for Debuffs — `MaxDuration` lives on Buffs only (see above), not Debuffs.
+- **`GetCrowdControlFilterString(db, is_friendly)`** — not multi-group, a plain `elseif`: `All`
+  (either reaction) returns an unrestricted Crowd Control filter string; Friendly with Dispellable
+  checked adds the `DISPELLABLE` token (gated on `is_friendly` since the Enemy Options panel exposes
+  no such toggle — reading `db.ShowDispellable` unconditionally would key off a boolean the Enemy UI
+  can never set); otherwise returns `nil` (group disabled). Its plain-string return (not the
+  group-keyed table shape the other four produce) is wrapped into the same shape via the
+  `SingleGroupConfig` helper before reaching `Widget:UpdateAuraContainer`.
+
+---
+
+## 6. Blizzard API quirks relevant to this widget
+
+Confirmed by reading Blizzard's own Lua source (`Interface/AddOns/Blizzard_AuraContainer/*.lua`)
+and/or in-game testing. Worth knowing before touching this code.
+
+- **`GetAuraGroupFrameCount(groupKey)` returns frame *pool* size, not live/displayed aura count.**
+  Per `Blizzard_AuraContainerFrameProviders.lua`,
+  `AuraContainerCustomFrameProviderMixin:GetOwnedFrameCount` → `#self.ownedFrames`. The pool grows in
+  batches and never shrinks, so this number reflects the group's historical peak, not its current
+  state. No safely addon-exposed "currently active aura count" API exists on `AuraContainer`
+  (`GetAuraGroupFrame`/`GetAuraGroupFrameCount`/`HasAuraGroup` are the only public
+  frame-introspection methods); `AuraButton:IsShown()` per-frame might work but is unverified.
+- **`candidateFilters.isFromPlayerOrPlayerPet` does not actually restrict anything** on this
+  client/patch — a group configured with it still shows auras from every caster, not just the
+  player/pet. The `PLAYER` filter-string token (older, part of the classic `AuraFilters` vocabulary)
+  is used instead everywhere "cast by me or my pet" filtering is needed. Root cause is unconfirmed —
+  worth rechecking if other boolean `candidateFilters` fields ever show similarly inert behavior.
+- **`IMPORTANT` only ever applies to helpful auras.** Per `AuraFilters`' own doc comment ("helpful
+  auras that show on enemy nameplates even if non-stealable"), combining it with `HARMFUL` matches
+  nothing at all. `candidateFilters.nameplateShowAll` (Blizzard's own default-nameplate curation flag)
+  has no such helpful-only restriction and is used instead wherever "what Blizzard's own nameplates
+  would show" semantics are needed — though for Enemy Debuffs' "Blizzard" toggle this is further
+  scoped to `PLAYER` on top, by deliberate design (see §5), so it no longer literally means "what
+  Blizzard would show for anyone", only for the player.
+- **`includeSpellIDs`/`excludeSpellIDs` are reaction-restricted; other `candidateFilters` boolean
+  fields are not.** Per `Blizzard_AuraContainerUtil.lua`'s `DoesAuraPassCandidateFilters`, only the
+  two spell-ID checks are gated behind `CanApplyIdentityCandidateFilters` (valid only for Friendly
+  Buffs and Enemy Debuffs/CrowdControl, silently no-op elsewhere). `isBossAura`/`includeDispelTypes`/
+  `canApplyAura`/etc. are checked unconditionally for every reaction/aura-type combination.
+- **`AuraButton`'s `initializeFrame` callback runs exactly once per physical frame**, at the moment
+  Blizzard's internal frame-pool provider creates it (`Blizzard_AuraContainerFrameProviders.lua`,
+  `AuraContainerCustomFrameProviderMixin:CreateFrame`, wrapped in `securecallfunction`) — never again
+  on reuse/recycling. Any setting only ever applied inside `InitializeAuraButton` is therefore
+  create-time-only unless something else re-applies it later. `ReapplyLiveAuraButtonSettings` does
+  this for icon size/tooltip-enable/cooldown-spiral (plain `Set*` calls, safe to repeat) by
+  enumerating already-created buttons via `GetAuraGroupFrame`/`GetAuraGroupFrameCount` and calling the
+  same setters again from `Widget:UpdateSettings`. Stack count/duration text visibility and the
+  dispel-type border toggle (`ShowAuraType`) are **not** covered by this — those conditionally
+  *create* child textures/fontstrings once, rather than just setting a property, and there's no
+  retroactive create/destroy path built for that; changing them in Options only affects newly-pooled
+  buttons.
+- **`AuraButton` carries `AccessRestrictionFlags = DenyTaintedAccessWhenAurasAreSecret`**
+  (`Blizzard_AuraContainerShared.lua`). `InitializeAuraButton`'s calls run inside Blizzard's own
+  `securecallfunction` wrapper and are therefore not tainted; `ReapplyLiveAuraButtonSettings`'s calls
+  happen from plain (tainted) addon code instead. Whether this restriction actually covers layout
+  setters like `SetSize` (versus only aura-data-revealing methods) isn't confirmed from source alone.
+  `ReapplyLiveAuraButtonSettings` is deferred via `Addon.ExecuteAfterCombatEnds` like every other
+  setting this addon can't safely change mid-combat, rather than risk it erroring on individual
+  buttons.
+- **No script-hook or callback exists on `AuraButton` for addon-attached visual effects** (glow
+  outlines, flash-on-expiring), per a full read of the `AuraButton` mixin. `LibCustomGlow`/
+  `Animation.Flash`-style hooks cannot attach.
+- **No `OnSizeChanged`/reliable `GetHeight`/`GetPoint` on these Forbidden-Aspect containers** — calls
+  throw "Can't measure restricted regions". This is why `UpdateAuraContainer`'s sibling-anchor offset
+  uses the sibling's *configured* max height (`Rows * IconHeight + ...`) rather than its actual
+  current rendered height — a container can't reliably report its own live size to another container
+  trying to anchor below/above it.
+- **`AuraContainerSortMethod` has no duration/creation-time sort value** — only
+  `Default`/`BigDefensive`/`UnitFrameDebuff`/`ImportantOnly`/`Expiration`/`ExpirationOnly`/`Name`/
+  `NameOnly`/`AuraInstanceIDOnly`. `SortOrder` settings of `"Duration"`/`"Creation"` fall back to
+  `Default` (`GetSortMethod`).
+- **`AddDispelTypeTexture`'s `customDispelColorMap` wants real `Color` objects** (`:GetRGBA()`
+  callable), not plain `{r=, g=, b=}` tables — `_G.DebuffTypeColor` (and this widget's own fallback
+  table) provide the latter, so `BuildDispelTypeColorMap` wraps each entry in `_G.CreateColor(...)`.
+  `customDispelColorCurve` (a `C_CurveUtil` color curve) is the alternative Blizzard also supports,
+  but needs a curve object; `customDispelColorMap` is functionally equivalent for this use case and
+  needs no such object.
+
+---
+
+## 7. Not implemented / not feasible on `AuraContainer` today
+
+"Feasible" means a concrete Blizzard API exists to build it; "Not feasible" means the underlying
+capability doesn't exist for addon code on `AuraButton`/`AuraContainer` as of Patch 12.1.0.
+
+| Feature | Status | 12.1.0 API path | Feasible? |
+| --- | --- | --- | --- |
+| Bar display mode | hidden (Options) | `SetDurationBar(statusBar, options)` exists on `AuraButton` | **Yes** — not built yet |
+| Highlight/glow (stealable-aura outline) | inert, not gated | none — no hook point (§6) | **No** |
+| Flash-on-expiring | inert, not gated | none — same as Highlight | **No** |
+| `SortOrder`: Duration / Creation | inert, falls back to Default | no enum value exists (§6) | **No** |
+| Config/Demo preview mode | stubbed (`Widget:ToggleConfigurationMode` no-ops) | none — `AuraContainer` only ever shows real data for a real `SetUnit()` token | **No**, not with the current mechanism |
+| `SwitchAuraAreaByReaction` | inert, not gated | pure Lua-side (`unit.reaction` is non-secret) — not an API blocker, just not wired in | **Yes** — trivial |
+| Per-spell whitelist/blacklist | hidden (Options) | `candidateFilters.includeSpellIDs`/`excludeSpellIDs`, reaction-restricted (§6) | **Yes, partially** |
+| "Dispellable (only me)" for Enemy Debuffs | not implemented | no Blizzard token/candidateFilters field for player-personal dispel capability exists — would need a static class/spec→dispel-type lookup table instead | **Yes, via workaround** |
+| Dynamic sibling-height anchoring (no wasted vertical gap above an empty grid) | not implemented (static max-height used instead) | none found — `GetAuraGroupFrameCount` is pool size not live count (§6), no `GetHeight` on Forbidden containers | **No**, not with a currently-known API |
+
+---
+
+## 8. References
+
+- WoW API wiki: [`API_types/AuraFilters`](https://warcraft.wiki.gg/wiki/API_types/AuraFilters)
+- Blizzard source (`Interface/AddOns/Blizzard_AuraContainer/`): `Blizzard_CustomAuraContainer.lua`,
+  `Blizzard_AuraContainerFrameProviders.lua`, `Blizzard_AuraContainerUtil.lua`,
+  `Blizzard_AuraContainerShared.lua`, `Blizzard_AuraButton.lua`/`.xml`, `Blizzard_CustomAuraButton.lua`

--- a/Source/Wiki/AurasWidgetImplementation.md
+++ b/Source/Wiki/AurasWidgetImplementation.md
@@ -167,6 +167,22 @@ and/or in-game testing. Worth knowing before touching this code.
   state. No safely addon-exposed "currently active aura count" API exists on `AuraContainer`
   (`GetAuraGroupFrame`/`GetAuraGroupFrameCount`/`HasAuraGroup` are the only public
   frame-introspection methods); `AuraButton:IsShown()` per-frame might work but is unverified.
+- **`SetMouseMotionEnabled` alone is not enough for tooltips to appear - `SetTooltipAnchorPoint` must
+  also be called at least once.** `OnEnter_Intrinsic`/`OnLeave_Intrinsic` are wired into the button
+  automatically (`Blizzard_AuraButton.xml`, not addon-scriptable), and `ShowTooltip()` calls
+  `tooltip:SetOwner(self, self:GetTooltipAnchorPoint())` - but `GetTooltipAnchorPoint()` returns
+  `self.tooltipAnchorPoint`, which is `nil` until `SetTooltipAnchorPoint(point, offsetX, offsetY)` is
+  called (`OnLoad_Intrinsic` never initializes it). Without that call, every tooltip attempt calls
+  `SetOwner` with a `nil` anchor and no tooltip ever appeared, confirmed live. Fixed by calling
+  `auraButton:SetTooltipAnchorPoint("ANCHOR_RIGHT")` once in `InitializeAuraButton`.
+- **`SetHideTooltipInCombat(true)` hides tooltips in combat - this widget doesn't want that.** Was set
+  unconditionally `true` (pre-existing, before this session's tooltip work), which per
+  `AuraButtonPrivateMixin:ShouldShowTooltip()` suppresses the tooltip entirely whenever
+  `UnitAffectingCombat("player")` is true - unrelated to the anchor-point bug above, a second,
+  independent reason tooltips didn't work. Blizzard's own default unit-frame auras still show
+  tooltips in combat (verified live by user), so this was an unnecessary restriction this widget
+  introduced on its own, not something inherited from Blizzard's own behavior. Fixed by switching to
+  `SetHideTooltipInCombat(false)`.
 - **`candidateFilters.isFromPlayerOrPlayerPet` does not actually restrict anything** on this
   client/patch — a group configured with it still shows auras from every caster, not just the
   player/pet. The `PLAYER` filter-string token (older, part of the classic `AuraFilters` vocabulary)

--- a/TidyPlates_ThreatPlates_Changes.log
+++ b/TidyPlates_ThreatPlates_Changes.log
@@ -1,4 +1,10 @@
 ﻿------------------------------------------------------
+13.1.0 (2026-08-12)
+------------------------------------------------------
+* Fix Lua error when displaying auras on nameplates caused by restrictions on secret values [GH-723].
+* Rebuilt the Auras widget on top of Patch 12.1.0's new AuraContainer API, since the old aura-scanning method no longer works reliably. Currently only rudimentary aura features are available as a result.
+
+------------------------------------------------------
 13.0.30 (2026-08-11)
 ------------------------------------------------------
 * Fixed a Lua error in the Auras widget when aura highlighting was enabled [GH-719].

--- a/Widgets/AurasWidget.lua
+++ b/Widgets/AurasWidget.lua
@@ -1714,11 +1714,12 @@ Widget.FILTER_FUNCTIONS = {
 
 if Addon.WOW_FEATURE_BLIZZARD_AURA_FILTER then
   function Widget:FilterFriendlyDebuffsBySpell(db, aura, AuraFilterFunction)
+    -- Dispellable ("Bannbar") and Dispel Type ("Bannart") are combined, not independent: Bannart only
+    -- takes effect while Bannbar is also on, and then only dispellable debuffs of a checked type show.
     local show_aura = db.ShowAllFriendly or
                       (db.ShowBlizzardForFriendly and (aura.nameplateShowAll or (aura.nameplateShowPersonal and aura.CastByPlayer))) or
-                      (db.ShowDispellable and aura.isStealable) or
                       (db.ShowBoss and aura.isBossAura) or
-                      (aura.dispelName and db.FilterByType[self.AURA_TYPE[aura.dispelName]])
+                      (db.ShowDispellable and aura.isStealable and aura.dispelName and db.FilterByType[self.AURA_TYPE[aura.dispelName]])
 
     local spellfound = self.AuraFilterDebuffs[aura.name] or self.AuraFilterDebuffs[aura.spellId]
 
@@ -1757,11 +1758,12 @@ if Addon.WOW_FEATURE_BLIZZARD_AURA_FILTER then
 else
   -- ShowBlizzard... is not supported in Classic
   function Widget:FilterFriendlyDebuffsBySpell(db, aura, AuraFilterFunction)
+    -- Dispellable ("Bannbar") and Dispel Type ("Bannart") are combined, not independent: Bannart only
+    -- takes effect while Bannbar is also on, and then only dispellable debuffs of a checked type show.
     local show_aura = db.ShowAllFriendly or
       -- (db.ShowBlizzardForFriendly and (aura.nameplateShowAll or (aura.nameplateShowPersonal and aura.CastByPlayer))) or
-      (db.ShowDispellable and aura.isStealable) or
       (db.ShowBoss and aura.isBossAura) or
-      (aura.dispelName and db.FilterByType[self.AURA_TYPE[aura.dispelName]])
+      (db.ShowDispellable and aura.isStealable and aura.dispelName and db.FilterByType[self.AURA_TYPE[aura.dispelName]])
 
     local spellfound = self.AuraFilterDebuffs[aura.name] or self.AuraFilterDebuffs[aura.spellId]
 

--- a/Widgets/AurasWidgetMidnight.lua
+++ b/Widgets/AurasWidgetMidnight.lua
@@ -77,10 +77,9 @@ local EnabledForStyle = {}
 -- - Per-spell FilterBySpell (spell name/ID text list) is not implemented; candidateFilters.
 --   includeSpellIDs/excludeSpellIDs would only be usable for Debuffs+CrowdControl on enemies anyway
 --   (Blizzard restricts spell-ID candidate filters to helpful-on-assistable/harmful-on-non-assistable).
--- - Dispel-type border coloring is not implemented (SetAuraBorder rendered incorrectly in testing -
---   most buffs have no dispel type to begin with).
--- - Visual settings (font/size/tooltip/stack count/duration text visibility) are only applied once,
---   at pool-creation time - changing them in Options during the same session does not re-skin
+-- - Visual settings (font/size/tooltip/stack count/duration text visibility, including whether the
+--   dispel-type border is drawn at all via ShowAuraType) are only applied once, at pool-creation time
+--   - changing them in Options during the same session does not re-skin
 --   already-pooled AuraButtons (Forbidden Aspects mean there is no per-aura Lua hook to reapply
 --   style on demand, unlike the old manual icon-frame system).
 -- - The demo/preview "Configuration Mode" and the aura-trigger custom-plate-style system (both
@@ -109,6 +108,31 @@ local AURA_GROUP_KEYS = {
 }
 local DISPEL_TYPE_NAMES = { "Curse", "Disease", "Magic", "Poison" } -- index matches Debuffs.FilterByType[1..4]
 
+-- Dispel-type border coloring (AuraWidget.ShowAuraType/DefaultBuffColor/DefaultDebuffColor, shared
+-- across Buffs/Debuffs/CrowdControl - see Constants.lua). AddDispelTypeTexture's customDispelColorMap
+-- wants real Color objects (needs :GetRGBA()), not the plain {r=,g=,b=} tables _G.DebuffTypeColor (or
+-- the legacy AurasWidget.lua fallback of the same shape) provides - built once here. customDispelColorCurve
+-- (a C_CurveUtil color curve) is the alternative Blizzard also supports, but customDispelColorMap is a
+-- plain name->color table and needs no curve object to reconstruct, so it's used here instead.
+local function BuildDispelTypeColorMap()
+  local source = _G.DebuffTypeColor or {
+    Magic = { r = 0.20, g = 0.60, b = 1.00 },
+    Disease = { r = 0.60, g = 0.40, b = 0.00 },
+    Poison = { r = 0.00, g = 0.60, b = 0.00 },
+    Curse = { r = 0.60, g = 0.00, b = 1.00 },
+  }
+  local map = {}
+  for _, dispel_name in ipairs(DISPEL_TYPE_NAMES) do
+    local color = source[dispel_name]
+    if color then
+      map[dispel_name] = _G.CreateColor(color.r, color.g, color.b, 1)
+    end
+  end
+  return map
+end
+
+local DISPEL_TYPE_COLOR_MAP = BuildDispelTypeColorMap()
+
 local AuraContainerPool = { Buffs = {}, Debuffs = {}, CrowdControl = {} }
 local NextAuraContainerIndex = { Buffs = 1, Debuffs = 1, CrowdControl = 1 }
 
@@ -119,6 +143,25 @@ local function InitializeAuraButton(auraButton, aura_type)
   auraButton.Icon:SetAllPoints(auraButton)
   auraButton.Icon:SetTexCoord(.10, 1 - .07, .12, 1 - .12) -- Style: Square - remove border from icons
   auraButton:SetIcon(auraButton.Icon)
+
+  if Widget.db.ShowAuraType then
+    -- Border style + showWithoutDispelType=false: only draws when the aura actually has a dispel
+    -- type (most buffs don't), colored via customDispelColorMap instead of Blizzard's own per-type
+    -- atlas color, matching the legacy widget's DebuffTypeColor-based coloring.
+    auraButton.DispelBorder = auraButton:CreateTexture(nil, "OVERLAY")
+    -- PixelUtil (not plain SetPoint) so the outset is a crisp, consistent number of screen pixels
+    -- regardless of UI scale - a plain SetPoint offset could land sub-pixel and look like it's not
+    -- quite reaching the icon's edge.
+    PixelUtil.SetPoint(auraButton.DispelBorder, "TOPLEFT", auraButton, "TOPLEFT", -3, 3)
+    PixelUtil.SetPoint(auraButton.DispelBorder, "BOTTOMRIGHT", auraButton, "BOTTOMRIGHT", 3, -3)
+    auraButton:AddDispelTypeTexture(auraButton.DispelBorder, {
+      style = _G.Enum.CustomAuraButtonDispelTypeTextureStyle.Border,
+      showWhenHarmful = true,
+      showWhenHelpful = true,
+      showWithoutDispelType = false,
+      customDispelColorMap = DISPEL_TYPE_COLOR_MAP,
+    })
+  end
 
   auraButton.Cooldown = Addon.CreateCooldown(auraButton, HideOmniCC)
   auraButton.Cooldown:SetShownSwipe(Widget.db.ShowCooldownSpiral, HideOmniCC)
@@ -327,31 +370,35 @@ local function GetEnemyBuffsGroupConfigs(db, unit)
   return BuildGroupConfigsFromConditions(conditions, { "HELPFUL", NAMEPLATE_ONLY })
 end
 
--- Debuffs (friendly): same multi-group independent-OR-condition pattern as Debuffs (enemy) below
--- (Dispellable/Boss/FilterByType are the legacy friendly-only fields, see the note above their
--- Constants.lua defaults). ShowAllFriendly short-circuits everything into "main" alone.
+-- Debuffs (friendly): same multi-group independent-OR-condition pattern as Debuffs (enemy) below,
+-- except Dispellable+FilterByType are combined rather than independent - see the note in
+-- GetEnemyDebuffsGroupConfigs (Dispellable/Boss/FilterByType are the legacy friendly-only fields, see
+-- the note above their Constants.lua defaults). ShowAllFriendly short-circuits everything into "main"
+-- alone.
 local function GetFriendlyDebuffsGroupConfigs(db)
   if db.ShowAllFriendly then
     return { main = { filterString = "HARMFUL|!CROWD_CONTROL|" .. NAMEPLATE_ONLY, candidateFilters = {} } }
   end
 
   local conditions = {}
-  if db.ShowDispellable then
-    conditions[#conditions + 1] = { key = "dispellable", filterTokens = { "DISPELLABLE" }, candidateFilters = {} }
-  end
   if db.ShowBoss then
     conditions[#conditions + 1] = { key = "boss", filterTokens = {}, candidateFilters = { isBossAura = true } }
   end
 
+  -- Dispellable ("Bannbar") and Dispel Type ("Bannart") are combined, not independent - see the same
+  -- note in GetEnemyDebuffsGroupConfigs. Bannbar no longer has its own standalone group; it only
+  -- gates whether "dispeltype" exists, and that group always requires DISPELLABLE too.
   local dispel_types, has_dispel_type = {}, false
-  for i, dispel_name in ipairs(DISPEL_TYPE_NAMES) do
-    if db.FilterByType[i] then
-      dispel_types[dispel_name] = true
-      has_dispel_type = true
+  if db.ShowDispellable then
+    for i, dispel_name in ipairs(DISPEL_TYPE_NAMES) do
+      if db.FilterByType[i] then
+        dispel_types[dispel_name] = true
+        has_dispel_type = true
+      end
     end
-  end
-  if has_dispel_type then
-    conditions[#conditions + 1] = { key = "dispeltype", filterTokens = {}, candidateFilters = { includeDispelTypes = dispel_types } }
+    if has_dispel_type then
+      conditions[#conditions + 1] = { key = "dispeltype", filterTokens = { "DISPELLABLE" }, candidateFilters = { includeDispelTypes = dispel_types } }
+    end
   end
 
   return BuildGroupConfigsFromConditions(conditions, { "HARMFUL", "!CROWD_CONTROL", NAMEPLATE_ONLY }, dispel_types, has_dispel_type)
@@ -371,18 +418,20 @@ end
 
 -- Builds the full set of AddAuraGroup configs (per AURA_GROUP_KEYS.Debuffs key) for enemy-reaction
 -- Debuffs from today's boolean settings. ShowAllEnemy short-circuits everything into "main" alone.
--- Otherwise each of ShowOnlyMine ("main"), ShowBlizzardForEnemy ("important", IMPORTANT auras),
--- ShowBoss ("boss", candidateFilters.isBossAura), ShowPriority ("priority",
--- candidateFilters.isPriorityAura), and ShowDispellable ("dispellable", DISPELLABLE auras) is an
--- independent, freely-combinable OR-condition: every group's filter string/candidateFilters excludes
--- every *earlier-listed* active condition (see BuildGroupConfigsFromConditions), so an aura matching
--- more than one toggle is always assigned to exactly one group - the earliest one it satisfies -
--- instead of showing twice or (with the naive "exclude every other condition in both directions"
--- approach this used to have) vanishing from both. FilterByType[1-4] ("dispeltype") is
--- built the same way, but since candidateFilters.includeDispelTypes is a table (not a plain boolean/
--- token), it can't be negated into the other groups' filters the same way - instead, every other
--- group explicitly excludes the checked dispel types via candidateFilters.excludeDispelTypes, so an
--- aura matching e.g. both a checked dispel type and Boss only ever shows via "dispeltype".
+-- Otherwise each of ShowOnlyMine ("main"), ShowBlizzardForEnemy ("important", candidateFilters.nameplateShowAll),
+-- ShowBoss ("boss", candidateFilters.isBossAura), and ShowPriority ("priority",
+-- candidateFilters.isPriorityAura) is an independent, freely-combinable OR-condition: every group's
+-- filter string/candidateFilters excludes every *earlier-listed* active condition (see
+-- BuildGroupConfigsFromConditions), so an aura matching more than one toggle is always assigned to
+-- exactly one group - the earliest one it satisfies - instead of showing twice or (with the naive
+-- "exclude every other condition in both directions" approach this used to have) vanishing from both.
+-- ShowDispellableEnemy ("Bannbar") and FilterByTypeEnemy[1-4] ("Bannart") are combined, not
+-- independent: Bannart only ever produces a "dispeltype" group when Bannbar is also on, and that
+-- group always includes the DISPELLABLE token - so it's not "every other group excludes the checked
+-- dispel types", it's "dispeltype only exists, and only matches dispellable auras, while Bannbar is
+-- on". Every *other* group still explicitly excludes the checked dispel types via
+-- candidateFilters.excludeDispelTypes whenever Bannbar+Bannart together produce a "dispeltype" group,
+-- so an aura matching e.g. both a checked dispellable type and Boss only ever shows via "dispeltype".
 --
 -- Returns a table keyed by group name -> { filterString = ..., candidateFilters = ... }; a group
 -- key that's missing from the result means "disable this group" (caller sets maxFrameCount to 0).
@@ -398,10 +447,20 @@ local function GetEnemyDebuffsGroupConfigs(db)
 
   local conditions = {}
   if db.ShowOnlyMine then
-    conditions[#conditions + 1] = { key = "main", filterTokens = {}, candidateFilters = { isFromPlayerOrPlayerPet = true } }
+    -- PLAYER filter-string token, not candidateFilters.isFromPlayerOrPlayerPet - live-tested and
+    -- confirmed candidateFilters.isFromPlayerOrPlayerPet doesn't actually restrict anything on this
+    -- client (debug dump showed it built/applied correctly - candidateFilters={isFromPlayerOrPlayerPet=true}
+    -- - yet all enemy debuffs still showed, not just self-cast ones). Switching to PLAYER fixed it,
+    -- confirmed by isolated retest (only "Mine" active): only self-cast debuffs shown afterwards.
+    conditions[#conditions + 1] = { key = "main", filterTokens = { "PLAYER" }, candidateFilters = {} }
   end
   if db.ShowBlizzardForEnemy then
-    conditions[#conditions + 1] = { key = "important", filterTokens = { "IMPORTANT" }, candidateFilters = {} }
+    -- Not the IMPORTANT token: per AuraFilters' own doc comment, IMPORTANT only ever applies to
+    -- helpful auras ("helpful auras that show on enemy nameplates even if non-stealable"), so
+    -- combined with HARMFUL here it matched nothing at all - confirmed live by user report.
+    -- nameplateShowAll is the real field behind the legacy "Blizzard" toggle's semantics
+    -- (aura.nameplateShowAll in AurasWidget.lua) and has no such helpful-only restriction.
+    conditions[#conditions + 1] = { key = "important", filterTokens = {}, candidateFilters = { nameplateShowAll = true } }
   end
   if db.ShowBossEnemy then
     conditions[#conditions + 1] = { key = "boss", filterTokens = {}, candidateFilters = { isBossAura = true } }
@@ -409,19 +468,31 @@ local function GetEnemyDebuffsGroupConfigs(db)
   if db.ShowPriority then
     conditions[#conditions + 1] = { key = "priority", filterTokens = {}, candidateFilters = { isPriorityAura = true } }
   end
-  if db.ShowDispellableEnemy then
-    conditions[#conditions + 1] = { key = "dispellable", filterTokens = { "DISPELLABLE" }, candidateFilters = {} }
-  end
-
+  -- Dispellable ("Bannbar") and Dispel Type ("Bannart") are combined, not independent: Bannart is
+  -- inert (and grayed out in Options) unless Bannbar is also on, and once it is, only *dispellable*
+  -- debuffs of a checked type show - not every dispellable debuff regardless of type like before.
+  -- So there's no separate standalone "dispellable" condition/group anymore - Bannbar's own toggle
+  -- only gates whether the "dispeltype" group exists at all.
   local dispel_types, has_dispel_type = {}, false
-  for i, dispel_name in ipairs(DISPEL_TYPE_NAMES) do
-    if db.FilterByTypeEnemy[i] then
-      dispel_types[dispel_name] = true
-      has_dispel_type = true
+  if db.ShowDispellableEnemy then
+    for i, dispel_name in ipairs(DISPEL_TYPE_NAMES) do
+      if db.FilterByTypeEnemy[i] then
+        dispel_types[dispel_name] = true
+        has_dispel_type = true
+      end
     end
-  end
-  if has_dispel_type then
-    conditions[#conditions + 1] = { key = "dispeltype", filterTokens = {}, candidateFilters = { includeDispelTypes = dispel_types } }
+    if has_dispel_type then
+      -- "dispeltype" is exempt from BuildGroupConfigsFromConditions' earlier-condition exclusion (see
+      -- its comment - includeDispelTypes is a table, can't be negated like a boolean/token), so Mine's
+      -- PLAYER token never reaches it through that mechanism. Add it directly here instead, so Mine +
+      -- a checked dispel type combine ("only my Curses/Diseases/...") instead of dispeltype always
+      -- showing every player's matching debuffs regardless of Mine.
+      local dispeltype_tokens = { "DISPELLABLE" }
+      if db.ShowOnlyMine then
+        dispeltype_tokens[#dispeltype_tokens + 1] = "PLAYER"
+      end
+      conditions[#conditions + 1] = { key = "dispeltype", filterTokens = dispeltype_tokens, candidateFilters = { includeDispelTypes = dispel_types } }
+    end
   end
 
   local configs = BuildGroupConfigsFromConditions(conditions, { "HARMFUL", "!CROWD_CONTROL", NAMEPLATE_ONLY }, dispel_types, has_dispel_type)

--- a/Widgets/AurasWidgetMidnight.lua
+++ b/Widgets/AurasWidgetMidnight.lua
@@ -12,68 +12,29 @@ local Widget = Addon.Widgets:NewWidget("Auras")
 ---------------------------------------------------------------------------------------------------
 
 -- Lua APIs
-local GetTime = GetTime
-local pairs = pairs
-local floor, ceil, min = floor, ceil, min
-local sort = sort
-local tonumber = tonumber
-
--- WoW APIs
-local GetFramerate = GetFramerate
-local IsAuraFilteredOutByInstanceID, GetAuraDuration = C_UnitAuras.IsAuraFilteredOutByInstanceID, C_UnitAuras.GetAuraDuration
-local GetAuraApplicationDisplayCount = C_UnitAuras.GetAuraApplicationDisplayCount
-local GetAuraDispelTypeColor = C_UnitAuras.GetAuraDispelTypeColor
-local AuraBarInterpolation = Enum.StatusBarInterpolation and Enum.StatusBarInterpolation.Immediate
-local RemainingTimeDirection = Enum.StatusBarTimerDirection and Enum.StatusBarTimerDirection.RemainingTime
+local min = min
 
 -- ThreatPlates APIs
-local AnimationStopFlash, AnimationFlash = Addon.Animation.StopFlash, Addon.Animation.Flash
 local FontUpdateText = Addon.Font.UpdateText
 local AuraTriggerInitialize, AuraTriggerUpdateStyle = Addon.Style.AuraTriggerInitialize, Addon.Style.AuraTriggerUpdateStyle
-local CUSTOM_GLOW_FUNCTIONS, CUSTOM_GLOW_WRAPPER_FUNCTIONS = Addon.CUSTOM_GLOW_FUNCTIONS, Addon.CUSTOM_GLOW_WRAPPER_FUNCTIONS
-local BackdropTemplate = Addon.BackdropTemplate
 local MODE_FOR_STYLE, AnchorFrameTo = Addon.MODE_FOR_STYLE, Addon.AnchorFrameTo
-local IsSecretValueTP, EvaluateColorValueFromBoolean = Addon.IsSecretValue, Addon.EvaluateColorValueFromBoolean
 local UnitIsUnitTP = Addon.UnitIsUnit
+
+-- Patch 12.1.0: AuraContainer/AuraButton is Blizzard's replacement for addon-side aura scanning
+-- (AuraUtil.ForEachAura/C_UnitAuras.GetUnitAuras) - it's secret-safe by design (Blizzard owns aura
+-- fetching internally once SetUnit() is called), whereas the old addon-side pull model can throw or
+-- come back empty for nameplate unit tokens even outside restricted periods [GH-723]. This is the
+-- only aura display path in this widget; there is no addon-side fallback. Feature-detected the same
+-- way Plater-Nameplates does it, since there is no dedicated expansion-level flag for this - only a
+-- template-existence check.
+local HasAuraContainers = C_XMLUtil and C_XMLUtil.GetTemplateInfo and C_XMLUtil.GetTemplateInfo("CustomAuraContainerTemplate") and true or false
+local AuraContainerSortMethod = _G.AuraContainerSortMethod
+local AuraContainerSortDirection = _G.AuraContainerSortDirection
 
 local _G =_G
 -- Global vars/functions that we don't upvalue since they might get hooked, or upgraded
 -- List them here for Mikk's FindGlobals script
--- GLOBALS: CreateFrame, UnitAffectingCombat
-
----------------------------------------------------------------------------------------------------
--- Constants
----------------------------------------------------------------------------------------------------
-
-local GRID_LAYOUT = {
-  LEFT = {
-    BOTTOM =  { "BOTTOMLEFT", "BOTTOMRIGHT", "BOTTOMLEFT", "TOPLEFT"   ,    1,  1},
-    TOP    =  { "BOTTOMLEFT", "BOTTOMRIGHT", "TOPLEFT",    "BOTTOMLEFT",    1, -1},
-  },
-  RIGHT = {
-    BOTTOM =  { "BOTTOMRIGHT", "BOTTOMLEFT", "BOTTOMRIGHT", "TOPRIGHT",    -1,  1},
-    TOP    =  { "TOPRIGHT"   , "TOPLEFT",    "TOPRIGHT",    "BOTTOMRIGHT", -1, -1},
-  },
-}
-
-Widget.TEXTURE_BORDER = Addon.ADDON_DIRECTORY .. "Artwork\\squareline"
-
--- Debuffs are color coded, with poison debuffs having a green border, magic debuffs a blue border, diseases a brown border,
--- urses a purple border, and physical debuffs a red border
-Widget.AURA_TYPE = { Curse = 1, Disease = 2, Magic = 3, Poison = 4, }
-
-Widget.ANCHOR_POINT_SETPOINT = Addon.ANCHOR_POINT_SETPOINT
-
--- Aura Grids
-Widget.Buffs = {
-  CenterAurasPositions = {},
-}
-Widget.Debuffs = {
-  CenterAurasPositions = {}
-}
-Widget.CrowdControl = {
-  CenterAurasPositions = {}
-}
+-- GLOBALS: CreateFrame, UIParent, InCombatLockdown, AnchorUtil, PixelUtil
 
 ---------------------------------------------------------------------------------------------------
 -- Crowd Control Auras
@@ -86,379 +47,491 @@ local CROWD_CONTROL_SPELLS_BY_EXPANSION = {
 Widget.CROWD_CONTROL_SPELLS = CROWD_CONTROL_SPELLS_BY_EXPANSION[Addon.GetExpansionLevel()]
 
 ---------------------------------------------------------------------------------------------------
--- Global attributes
----------------------------------------------------------------------------------------------------
---local PLayerIsInCombat = false
---local DispellableDebuffCache = {}
-
----------------------------------------------------------------------------------------------------
 -- Cached configuration settings
 ---------------------------------------------------------------------------------------------------
-local HideOmniCC, SetNoCooldownCount, ShowDuration, SortFunction
-local AuraHighlightEnabled, AuraHighlightStart, AuraHighlightStop, AuraHighlightStopPrevious, AuraHighlightOffset
-local AuraHighlightColor = { 0, 0, 0, 0 }
+local HideOmniCC, ShowDuration
 local EnabledForStyle = {}
 
 ---------------------------------------------------------------------------------------------------
--- OnUpdate code - updates the auras remaining uptime and stacks and hides them after they expired
+-- AuraContainer (Patch 12.1.0)
 ---------------------------------------------------------------------------------------------------
+-- Buffs, Debuffs, and CrowdControl are all AuraContainer-driven, for both friendly and enemy units.
+--
+-- Known simplifications versus the addon's pre-AuraContainer Filter*BySpell functions:
+-- - Buffs and Debuffs (both reactions) support independent, freely-combinable OR-conditions via one
+--   AddAuraGroup per condition (see BuildGroupConfigsFromConditions and its callers). ShowAll*/
+--   ShowOn*NPCs always short-circuit into a single unrestricted group first, though - "All on NPCs" is
+--   conceptually "All, but scoped to NPCs", not a peer condition, and can't be freely combined with
+--   the others the normal way (no candidateFilters field for "unit is an NPC" to cross-exclude it
+--   with). Debuffs additionally supports MaxDuration (enemy only) as an AND-restriction on top of
+--   whichever OR-condition(s) are active. CrowdControl (either reaction) is still single-condition
+--   only (All vs. Dispellable, a plain "elseif") - not converted to the multi-group pattern.
+-- - A crowd-control-classified aura is strictly exclusive to the CrowdControl grid (filtered out of
+--   Debuffs via "!CROWD_CONTROL"); the old per-aura fallback (show as a normal debuff if the
+--   CC-specific filter rejects it) is not replicated.
+-- - SwitchAreaByReaction (swapping which screen position shows buffs vs. debuffs for friendly units)
+--   is not implemented - each AuraContainer's aura type (buff/debuff) is now fixed to its own screen
+--   position for both reactions.
+-- - SortOrder "Duration"/"Creation" have no AuraContainerSortMethod equivalent and fall back to
+--   Default (None/AtoZ/TimeLeft+Reverse are supported via GetSortMethod/GetSortDirection).
+-- - Per-spell FilterBySpell (spell name/ID text list) is not implemented; candidateFilters.
+--   includeSpellIDs/excludeSpellIDs would only be usable for Debuffs+CrowdControl on enemies anyway
+--   (Blizzard restricts spell-ID candidate filters to helpful-on-assistable/harmful-on-non-assistable).
+-- - Dispel-type border coloring is not implemented (SetAuraBorder rendered incorrectly in testing -
+--   most buffs have no dispel type to begin with).
+-- - Visual settings (font/size/tooltip/stack count/duration text visibility) are only applied once,
+--   at pool-creation time - changing them in Options during the same session does not re-skin
+--   already-pooled AuraButtons (Forbidden Aspects mean there is no per-aura Lua hook to reapply
+--   style on demand, unlike the old manual icon-frame system).
+-- - The demo/preview "Configuration Mode" and the aura-trigger custom-plate-style system (both
+--   already non-functional prior to this) have no equivalent hook into AuraContainer and remain
+--   unavailable.
+-- - Debuffs' "dispeltype" group (FilterByType[1-4]) does not exclude the other Debuffs groups from
+--   itself (an aura matching a checked dispel type AND e.g. Boss shows via both groups); this is a
+--   real gap, unlike the reverse direction (other groups excluding checked dispel types from
+--   themselves via candidateFilters.excludeDispelTypes), which is handled - see
+--   GetEnemyDebuffsGroupConfigs/GetFriendlyDebuffsGroupConfigs.
 
-local function OnShowHookScript(widget_frame)
-  widget_frame.Buffs.TimeSinceLastUpdate = 0
-  widget_frame.Debuffs.TimeSinceLastUpdate = 0
-  widget_frame.CrowdControl.TimeSinceLastUpdate = 0
-end
+-- Without this, auras Blizzard flags as nameplate-only are silently excluded (AuraUtil.lua's
+-- IncludeNameplateOnly doc comment). Blizzard's own default nameplates always include this token in
+-- both their buff and debuff filter strings (Blizzard_NamePlateAuras.lua) - matched here for parity.
+local NAMEPLATE_ONLY = "INCLUDE_NAME_PLATE_ONLY"
 
----------------------------------------------------------------------------------------------------
--- Code for showing tooltips on auras
----------------------------------------------------------------------------------------------------
-
-local AuraTooltip = CreateFrame("GameTooltip", "ThreatPlatesAuraTooltip", UIParent, "GameTooltipTemplate")
-local AuraFrameOnEnter
-
-local function AuraFrameOnLeave(self)
-  AuraTooltip:Hide()
-end
-
--- SetUnitAuraByAuraInstanceID: WoW Midnight
--- SetUnitBuffByAuraInstanceID, SetUnitDebuffByAuraInstanceID: Dragonflight - Patch 10.0.0
--- Would show more information, but mainly about the spell, not the aura
--- AuraTooltip:SetSpellByID(self.AuraData.spellId)
-if AuraTooltip.SetUnitAuraByAuraInstanceID then
-  AuraFrameOnEnter = function(self)
-    AuraTooltip:SetOwner(self, "ANCHOR_LEFT")
-    AuraTooltip:SetUnitAuraByAuraInstanceID(self:GetParent():GetParent().unit.unitid, self.AuraData.auraInstanceID)
-  end
-elseif AuraTooltip.SetUnitBuffByAuraInstanceID and AuraTooltip.SetUnitDebuffByAuraInstanceID then
-  AuraFrameOnEnter = function(self)
-    AuraTooltip:SetOwner(self, "ANCHOR_LEFT")
-
-    -- I really think that SetUnit...ByAuraInstanceID does not the filter parameter, but still ...
-    if self.AuraData.effect == "HELPFUL" then
-      AuraTooltip:SetUnitBuffByAuraInstanceID(self:GetParent():GetParent().unit.unitid, self.AuraData.auraInstanceID, self.AuraData.effect)
-    else
-      AuraTooltip:SetUnitDebuffByAuraInstanceID(self:GetParent():GetParent().unit.unitid, self.AuraData.auraInstanceID, self.AuraData.effect)
-    end
-  end
-else
-  AuraFrameOnEnter = function(self)
-    AuraTooltip:SetOwner(self, "ANCHOR_LEFT")
-    AuraTooltip:SetUnitAura(self:GetParent():GetParent().unit.unitid, self.AuraData.auraInstanceID, self.AuraData.effect)
-  end
-end
-
----------------------------------------------------------------------------------------------------
--- Filtering and sorting functions
----------------------------------------------------------------------------------------------------
-
-local DEBUFF_DISPLAY_COLOR_INFO = {
-  [0] = DEBUFF_TYPE_NONE_COLOR,
-  [1] = DEBUFF_TYPE_MAGIC_COLOR,
-  [2] = DEBUFF_TYPE_CURSE_COLOR,
-  [3] = DEBUFF_TYPE_DISEASE_COLOR,
-  [4] = DEBUFF_TYPE_POISON_COLOR,
-  [9] = DEBUFF_TYPE_BLEED_COLOR, -- enrage
-  [11] = DEBUFF_TYPE_BLEED_COLOR,
+local AURA_CONTAINER_POOL_SIZE = 40 -- matches the practical max concurrent nameplate count (same assumption Plater-Nameplates uses)
+local AURA_CONTAINER_TYPES = { "Buffs", "Debuffs", "CrowdControl" }
+-- AddAuraGroup keys declared per aura type - Debuffs (either reaction) and Buffs (friendly) get one
+-- group per independent OR-condition (see GetEnemyDebuffsGroupConfigs/GetFriendlyDebuffsGroupConfigs/
+-- GetFriendlyBuffsGroupConfigs); Buffs (enemy) and CrowdControl (either reaction) only ever use "main".
+local AURA_GROUP_KEYS = {
+  Buffs = { "main", "canapply", "bigdefensive", "dispellable", "magic" },
+  Debuffs = { "main", "important", "boss", "priority", "dispellable", "dispeltype" },
+  CrowdControl = { "main" },
 }
+local DISPEL_TYPE_NAMES = { "Curse", "Disease", "Magic", "Poison" } -- index matches Debuffs.FilterByType[1..4]
 
-local DispelColorCurve = C_CurveUtil.CreateColorCurve()
+local AuraContainerPool = { Buffs = {}, Debuffs = {}, CrowdControl = {} }
+local NextAuraContainerIndex = { Buffs = 1, Debuffs = 1, CrowdControl = 1 }
 
-DispelColorCurve:SetType(Enum.LuaCurveType.Step)
-for i, c in pairs(DEBUFF_DISPLAY_COLOR_INFO) do
-  DispelColorCurve:AddPoint(i, c)
+local function InitializeAuraButton(auraButton, aura_type)
+  local db_icon = Widget.db[aura_type].ModeIcon
+
+  auraButton.Icon = auraButton:CreateTexture(nil, "ARTWORK", nil, -5)
+  auraButton.Icon:SetAllPoints(auraButton)
+  auraButton.Icon:SetTexCoord(.10, 1 - .07, .12, 1 - .12) -- Style: Square - remove border from icons
+  auraButton:SetIcon(auraButton.Icon)
+
+  auraButton.Cooldown = Addon.CreateCooldown(auraButton, HideOmniCC)
+  auraButton.Cooldown:SetShownSwipe(Widget.db.ShowCooldownSpiral, HideOmniCC)
+  auraButton:SetDurationCooldown(auraButton.Cooldown)
+
+  if Widget.db.ShowStackCount then
+    -- Font must be set before SetApplicationCount below: it triggers an immediate
+    -- UpdateAuraDisplay() -> FontString:SetText(), which errors ("Font not set") on a FontString
+    -- that was just created with CreateFontString(nil, ...) and has no font applied yet.
+    auraButton.Stacks = auraButton:CreateFontString(nil, "OVERLAY")
+    auraButton.Stacks:SetJustifyH("right")
+    auraButton.Stacks:SetPoint("BOTTOMRIGHT", 3, -2)
+    FontUpdateText(auraButton, auraButton.Stacks, db_icon.StackCount)
+    auraButton:SetApplicationCount(auraButton.Stacks)
+  end
+
+  if ShowDuration then
+    -- Same font-before-Set* ordering requirement as SetApplicationCount above.
+    auraButton.TimeLeft = auraButton:CreateFontString(nil, "OVERLAY")
+    FontUpdateText(auraButton, auraButton.TimeLeft, db_icon.Duration)
+    auraButton:SetDurationText(auraButton.TimeLeft)
+  end
+
+  -- AuraButton tooltips are managed by Blizzard automatically; no AuraFrameOnEnter/GameTooltip code
+  -- needed on our side, just whether mouse interaction is enabled at all.
+  auraButton:SetMouseMotionEnabled(Widget.db.ShowTooltips)
+  auraButton:SetHideTooltipInCombat(true)
+
+  PixelUtil.SetSize(auraButton, db_icon.IconWidth, db_icon.IconHeight)
 end
 
-function Widget:GetColorForAura(aura, unitid)
-	local db = self.db
+-- Maps the widget's SortOrder setting to the closest AuraContainerSortMethod. Duration/Creation have
+-- no equivalent sort method and fall back to Default.
+local function GetSortMethod(sort_order)
+  if sort_order == "AtoZ" then
+    return AuraContainerSortMethod.Name
+  elseif sort_order == "TimeLeft" then
+    return AuraContainerSortMethod.Expiration
+  end
 
-  -- if aura.dispelName and db.ShowAuraType then
-  if db.ShowAuraType and Addon.ExpansionIsAtLeastMidnight then
-    local color = GetAuraDispelTypeColor(aura.unitid, aura.auraInstanceID, DispelColorCurve)
-    if color then
-      return color
+  return AuraContainerSortMethod.Default
+end
+
+local function GetSortDirection(sort_reverse)
+  return sort_reverse and AuraContainerSortDirection.Reverse or AuraContainerSortDirection.Normal
+end
+
+local function CreateAuraContainer(aura_type)
+  local container = _G.CreateFrame("AuraContainer", nil, _G.UIParent, "CustomAuraContainerTemplate")
+  local effect = (aura_type == "Buffs" and "HELPFUL") or "HARMFUL"
+  local group_options = {
+    initializeFrame = function(auraButton) InitializeAuraButton(auraButton, aura_type) end,
+    sortMethod = GetSortMethod(Widget.db.SortOrder),
+    sortDirection = GetSortDirection(Widget.db.SortReverse),
+  }
+
+  for _, group_key in ipairs(AURA_GROUP_KEYS[aura_type]) do
+    container:AddAuraGroup(group_key, effect, group_options)
+  end
+  container:SetEnabled(false)
+
+  return container
+end
+
+-- AuraContainers cannot be created during combat, so the pools are built once up front (called from
+-- Widget:OnEnable, which runs at login/reload - effectively always out of combat - and retried from
+-- Widget:PLAYER_REGEN_ENABLED/DISABLED in case the widget was first enabled mid-combat) rather than
+-- lazily per-plate like the rest of this widget's frames.
+local function PreallocateAuraContainers()
+  if not HasAuraContainers then return end
+
+  if _G.InCombatLockdown() then
+    Addon.Logging.Debug("    Auras: could not pre-allocate AuraContainer pools - in combat, will retry after combat ends.")
+    return
+  end
+
+  for _, aura_type in ipairs(AURA_CONTAINER_TYPES) do
+    local pool = AuraContainerPool[aura_type]
+    if #pool == 0 then
+      for i = 1, AURA_CONTAINER_POOL_SIZE do
+        pool[i] = CreateAuraContainer(aura_type)
+      end
     end
   end
+end
 
-  if aura.effect == "HARMFUL" then  
-    return db.DefaultDebuffColor
+local function AcquireAuraContainer(aura_type)
+  local pool = AuraContainerPool[aura_type]
+  local index = NextAuraContainerIndex[aura_type]
+  local container = pool[index]
+  if container then
+    NextAuraContainerIndex[aura_type] = index + 1
   else
-    return db.DefaultBuffColor
-	end
-end
-
-local function FilterNone(show_aura, spellfound, is_mine, show_only_mine)
-  return show_aura
-end
-
-local function FilterAllowlist(show_aura, spellfound, is_mine, show_only_mine)
-  if spellfound == "All" then
-    return show_aura
-  elseif spellfound == true then
-    return (show_only_mine == nil and show_aura) or (show_aura and ((show_only_mine and is_mine) or show_only_mine == false))
-  elseif spellfound == "My" then
-    return show_aura and is_mine
+    Addon.Logging.Error("|cffFF8800[AuraDebug]|r", aura_type, "pool exhausted at index", index, "- this plate will show no", aura_type)
   end
 
-  return false
+  return container
 end
 
-local function FilterBlocklist(show_aura, spellfound, is_mine, show_only_mine)
-  -- blacklist all auras, i.e., default is show all auras (no matter who casted it)
-  --   spellfound = true or All - blacklist this aura (from all casters)
-  --   spellfound = My          - blacklist only my aura
-  --   spellfound = nil         - show aura (spell not found in blacklist)
-  --   spellfound = Not         - show aura (found entry not relevant, ignore it)
+-- Composes the AuraFilters string/candidateFilters for each type/reaction combination from today's
+-- boolean settings. See the simplifications note above the pool constant.
 
-  if spellfound == "All" or spellfound == true then
+-- Shared multi-group builder: turns a list of independent OR-conditions into one AddAuraGroup config
+-- per condition. base_filter_parts is the always-present prefix (aura type plus any fixed exclusions,
+-- e.g. {"HARMFUL", "!CROWD_CONTROL", NAMEPLATE_ONLY}). dispel_types/has_dispel_type (optional) apply
+-- candidateFilters.excludeDispelTypes to every non-"dispeltype" condition - a "dispeltype" condition's
+-- own candidateFilters.includeDispelTypes is a table, so it can't be negated into a "!token"/
+-- false-boolean like every other condition; this is the inverse fix for that (see the comment on
+-- GetEnemyDebuffsGroupConfigs for the full duplication story this prevents).
+--
+-- Exclusion is *ordered*, not symmetric: each condition excludes only the conditions *before* it in
+-- the list, never the ones after. Excluding every other condition in both directions (as an earlier
+-- version of this function did) means an aura matching two simultaneously-active conditions fails
+-- *both* groups' restrictions and vanishes entirely - neither shown twice nor once, just gone. Ordered
+-- exclusion instead gives every aura exactly one home: it shows via the earliest-listed condition it
+-- satisfies, and every later condition explicitly excludes that earlier one from itself. Which
+-- condition "wins" for a double-matching aura is an arbitrary but deterministic tie-break (list order
+-- = the order each condition is pushed into `conditions` by the caller); the important part is that it
+-- always shows via exactly one group.
+--
+-- Returns a table keyed by group name -> { filterString = ..., candidateFilters = ... }; a group key
+-- from AURA_GROUP_KEYS[aura_type] missing from the result means "disable this group" (caller sets
+-- maxFrameCount to 0).
+local function BuildGroupConfigsFromConditions(conditions, base_filter_parts, dispel_types, has_dispel_type)
+  local configs = {}
+  for i, condition in ipairs(conditions) do
+    local filter_parts = {}
+    for _, part in ipairs(base_filter_parts) do
+      filter_parts[#filter_parts + 1] = part
+    end
+    local candidate_filters = {}
+    for field, value in pairs(condition.candidateFilters) do
+      candidate_filters[field] = value
+    end
+    for _, token in ipairs(condition.filterTokens) do
+      filter_parts[#filter_parts + 1] = token
+    end
+
+    if condition.key ~= "dispeltype" then
+      for j = 1, i - 1 do
+        local other = conditions[j]
+        for _, token in ipairs(other.filterTokens) do
+          filter_parts[#filter_parts + 1] = "!" .. token
+        end
+        for field, value in pairs(other.candidateFilters) do
+          if type(value) == "boolean" and candidate_filters[field] == nil then
+            candidate_filters[field] = false
+          end
+        end
+      end
+
+      if has_dispel_type then
+        candidate_filters.excludeDispelTypes = dispel_types
+      end
+    end
+
+    configs[condition.key] = { filterString = table.concat(filter_parts, "|"), candidateFilters = candidate_filters }
+  end
+
+  return configs
+end
+
+-- Buffs (friendly): ShowAllFriendly/ShowOnFriendlyNPCs (unit.type == "NPC" only) short-circuit into an
+-- unrestricted "main" group, same as "All" everywhere else - "All on NPCs" is conceptually "All, but
+-- scoped to NPCs", not a peer condition, so it can't be freely combined with Mine/CanApply/
+-- BigDefensives the normal way (there's no candidateFilters field for "unit is an NPC" to cross-
+-- exclude it with; combining it as a peer group would double-render every other active condition's
+-- auras on NPC targets). Otherwise Mine/PlayerCanApply/BigDefensives are independent,
+-- freely-combinable OR-conditions.
+local function GetFriendlyBuffsGroupConfigs(db, unit)
+  if db.ShowAllFriendly or (db.ShowOnFriendlyNPCs and unit.type == "NPC") then
+    return { main = { filterString = "HELPFUL|" .. NAMEPLATE_ONLY, candidateFilters = {} } }
+  end
+
+  local conditions = {}
+  if db.ShowOnlyMine then
+    conditions[#conditions + 1] = { key = "main", filterTokens = { "PLAYER" }, candidateFilters = {} }
+  end
+  if db.ShowPlayerCanApply then
+    conditions[#conditions + 1] = { key = "canapply", filterTokens = {}, candidateFilters = { canApplyAura = true } }
+  end
+  if db.ShowFriendlyBigDefensives then
+    conditions[#conditions + 1] = { key = "bigdefensive", filterTokens = { "BIG_DEFENSIVE" }, candidateFilters = {} }
+  end
+
+  return BuildGroupConfigsFromConditions(conditions, { "HELPFUL", NAMEPLATE_ONLY })
+end
+
+-- Buffs (enemy): same pattern as Friendly above - ShowAllEnemy/ShowOnEnemyNPCs short-circuit,
+-- Dispellable/Magic are independent, freely-combinable OR-conditions.
+local function GetEnemyBuffsGroupConfigs(db, unit)
+  if db.ShowAllEnemy or (db.ShowOnEnemyNPCs and unit.type == "NPC") then
+    return { main = { filterString = "HELPFUL|" .. NAMEPLATE_ONLY, candidateFilters = {} } }
+  end
+
+  local conditions = {}
+  if db.ShowDispellable then
+    -- DISPELLABLE (Patch 12.1.0): dispellable by anyone, not just RAID_PLAYER_DISPELLABLE's "a raid
+    -- member's kit can dispel this specifically" - broader, matches what the "Dispellable" label implies.
+    conditions[#conditions + 1] = { key = "dispellable", filterTokens = { "DISPELLABLE" }, candidateFilters = {} }
+  end
+  if db.ShowMagic then
+    conditions[#conditions + 1] = { key = "magic", filterTokens = {}, candidateFilters = { includeDispelTypes = { Magic = true } } }
+  end
+
+  return BuildGroupConfigsFromConditions(conditions, { "HELPFUL", NAMEPLATE_ONLY })
+end
+
+-- Debuffs (friendly): same multi-group independent-OR-condition pattern as Debuffs (enemy) below
+-- (Dispellable/Boss/FilterByType are the legacy friendly-only fields, see the note above their
+-- Constants.lua defaults). ShowAllFriendly short-circuits everything into "main" alone.
+local function GetFriendlyDebuffsGroupConfigs(db)
+  if db.ShowAllFriendly then
+    return { main = { filterString = "HARMFUL|!CROWD_CONTROL|" .. NAMEPLATE_ONLY, candidateFilters = {} } }
+  end
+
+  local conditions = {}
+  if db.ShowDispellable then
+    conditions[#conditions + 1] = { key = "dispellable", filterTokens = { "DISPELLABLE" }, candidateFilters = {} }
+  end
+  if db.ShowBoss then
+    conditions[#conditions + 1] = { key = "boss", filterTokens = {}, candidateFilters = { isBossAura = true } }
+  end
+
+  local dispel_types, has_dispel_type = {}, false
+  for i, dispel_name in ipairs(DISPEL_TYPE_NAMES) do
+    if db.FilterByType[i] then
+      dispel_types[dispel_name] = true
+      has_dispel_type = true
+    end
+  end
+  if has_dispel_type then
+    conditions[#conditions + 1] = { key = "dispeltype", filterTokens = {}, candidateFilters = { includeDispelTypes = dispel_types } }
+  end
+
+  return BuildGroupConfigsFromConditions(conditions, { "HARMFUL", "!CROWD_CONTROL", NAMEPLATE_ONLY }, dispel_types, has_dispel_type)
+end
+
+local function GetCrowdControlFilterString(db, is_friendly)
+  if db.ShowAllFriendly or db.ShowAllEnemy then
+    return "HARMFUL|CROWD_CONTROL|" .. NAMEPLATE_ONLY
+  elseif is_friendly and db.ShowDispellable then
+    -- ShowDispellable only has a Friendly Options entry (Enemy Midnight panel exposes no such
+    -- toggle) - gate on is_friendly to keep it from also gating on a Boolean the enemy UI can't set.
+    return "HARMFUL|CROWD_CONTROL|DISPELLABLE|" .. NAMEPLATE_ONLY
+  end
+
+  return nil
+end
+
+-- Builds the full set of AddAuraGroup configs (per AURA_GROUP_KEYS.Debuffs key) for enemy-reaction
+-- Debuffs from today's boolean settings. ShowAllEnemy short-circuits everything into "main" alone.
+-- Otherwise each of ShowOnlyMine ("main"), ShowBlizzardForEnemy ("important", IMPORTANT auras),
+-- ShowBoss ("boss", candidateFilters.isBossAura), ShowPriority ("priority",
+-- candidateFilters.isPriorityAura), and ShowDispellable ("dispellable", DISPELLABLE auras) is an
+-- independent, freely-combinable OR-condition: every group's filter string/candidateFilters excludes
+-- every *earlier-listed* active condition (see BuildGroupConfigsFromConditions), so an aura matching
+-- more than one toggle is always assigned to exactly one group - the earliest one it satisfies -
+-- instead of showing twice or (with the naive "exclude every other condition in both directions"
+-- approach this used to have) vanishing from both. FilterByType[1-4] ("dispeltype") is
+-- built the same way, but since candidateFilters.includeDispelTypes is a table (not a plain boolean/
+-- token), it can't be negated into the other groups' filters the same way - instead, every other
+-- group explicitly excludes the checked dispel types via candidateFilters.excludeDispelTypes, so an
+-- aura matching e.g. both a checked dispel type and Boss only ever shows via "dispeltype".
+--
+-- Returns a table keyed by group name -> { filterString = ..., candidateFilters = ... }; a group
+-- key that's missing from the result means "disable this group" (caller sets maxFrameCount to 0).
+local function GetEnemyDebuffsGroupConfigs(db)
+  -- maxDuration (Patch 12.1.0): non-nil implicitly hides permanent auras too, per Blizzard's own
+  -- documentation - applied as an extra AND-restriction on every active group below (not its own
+  -- OR-condition/group), regardless of which other toggle(s) are active.
+  local max_duration = (db.MaxDuration and db.MaxDuration > 0) and db.MaxDuration or nil
+
+  if db.ShowAllEnemy then
+    return { main = { filterString = "HARMFUL|!CROWD_CONTROL|" .. NAMEPLATE_ONLY, candidateFilters = { maxDuration = max_duration } } }
+  end
+
+  local conditions = {}
+  if db.ShowOnlyMine then
+    conditions[#conditions + 1] = { key = "main", filterTokens = {}, candidateFilters = { isFromPlayerOrPlayerPet = true } }
+  end
+  if db.ShowBlizzardForEnemy then
+    conditions[#conditions + 1] = { key = "important", filterTokens = { "IMPORTANT" }, candidateFilters = {} }
+  end
+  if db.ShowBossEnemy then
+    conditions[#conditions + 1] = { key = "boss", filterTokens = {}, candidateFilters = { isBossAura = true } }
+  end
+  if db.ShowPriority then
+    conditions[#conditions + 1] = { key = "priority", filterTokens = {}, candidateFilters = { isPriorityAura = true } }
+  end
+  if db.ShowDispellableEnemy then
+    conditions[#conditions + 1] = { key = "dispellable", filterTokens = { "DISPELLABLE" }, candidateFilters = {} }
+  end
+
+  local dispel_types, has_dispel_type = {}, false
+  for i, dispel_name in ipairs(DISPEL_TYPE_NAMES) do
+    if db.FilterByTypeEnemy[i] then
+      dispel_types[dispel_name] = true
+      has_dispel_type = true
+    end
+  end
+  if has_dispel_type then
+    conditions[#conditions + 1] = { key = "dispeltype", filterTokens = {}, candidateFilters = { includeDispelTypes = dispel_types } }
+  end
+
+  local configs = BuildGroupConfigsFromConditions(conditions, { "HARMFUL", "!CROWD_CONTROL", NAMEPLATE_ONLY }, dispel_types, has_dispel_type)
+  for _, config in pairs(configs) do
+    config.candidateFilters.maxDuration = max_duration
+  end
+
+  return configs
+end
+
+-- Derives AuraContainer flow-layout anchor/growth direction from the widget's AlignmentH/AlignmentV
+-- settings (same semantics as the addon's other grid-layout alignment settings).
+local function GetFlowLayoutForAlignment(alignment_h, alignment_v)
+  local anchor_point = alignment_v .. alignment_h
+  local horizontal_direction = (alignment_h == "LEFT") and AnchorUtil.FlowDirection.Right or AnchorUtil.FlowDirection.Left
+  local vertical_direction = (alignment_v == "BOTTOM") and AnchorUtil.FlowDirection.Up or AnchorUtil.FlowDirection.Down
+
+  return anchor_point, horizontal_direction, vertical_direction
+end
+
+-- Configures the plate's pooled AuraContainer for aura_type ("Buffs"/"Debuffs"/"CrowdControl") for
+-- the current settings/unit and assigns the unit to it. Returns true if the container was enabled
+-- for this unit - the container manages its own aura-level visibility internally and
+-- asynchronously, so there is no "has active auras" count available here; callers use this return
+-- value (whether display was enabled at all, independent of actual aura presence) as a stand-in.
+-- group_configs: table keyed by group name ("main", and for Debuffs also "important"/"boss"/
+-- "priority"/"dispellable"/"dispeltype") -> { filterString = ..., candidateFilters = ... }. A group
+-- key from AURA_GROUP_KEYS[aura_type] missing from group_configs is disabled (maxFrameCount = 0).
+-- Buffs/CrowdControl callers only ever populate "main"; Debuffs callers may populate several.
+function Widget:UpdateAuraContainer(widget_frame, aura_type, group_configs, unit)
+  local container = widget_frame[aura_type .. "AuraContainer"]
+  if not container then return false end
+
+  if not group_configs or not next(group_configs) then
+    container:SetEnabled(false)
     return false
-  elseif spellfound == "My" then
-    return not is_mine
-  elseif spellfound == "Not" then
-    return true
   end
 
-  return show_aura
-end
+  local db = self.db[aura_type]
+  local db_icon = db.ModeIcon
+  local max_auras = min(db_icon.MaxAuras, db_icon.Rows * db_icon.Columns)
+  local anchor_point, horizontal_direction, vertical_direction = GetFlowLayoutForAlignment(db.AlignmentH, db.AlignmentV)
+  local sort_method = GetSortMethod(self.db.SortOrder)
+  local sort_direction = GetSortDirection(self.db.SortReverse)
+  local layout = {
+    elementWidth = db_icon.IconWidth,
+    elementHeight = db_icon.IconHeight,
+    elementSpacing = db_icon.ColumnSpacing,
+    lineSpacing = db_icon.RowSpacing,
+  }
 
-Widget.FILTER_FUNCTIONS = {
-  all = FilterNone,
-  blacklist = FilterBlocklist,
-  whitelist = FilterAllowlist,
-  None = FilterNone,
-  Block = FilterBlocklist,
-  Allow = FilterAllowlist,
-}
+  for _, group_key in ipairs(AURA_GROUP_KEYS[aura_type]) do
+    local config = group_configs[group_key]
+    if config then
+      container:SetAuraGroupFilterString(group_key, config.filterString)
+      container:SetAuraGroupCandidateFilters(group_key, config.candidateFilters)
+      container:SetAuraGroupMaxFrameCount(group_key, max_auras)
+      container:SetAuraGroupSortMethod(group_key, sort_method, sort_direction)
+      container:SetAuraGroupLayout(group_key, layout)
+    else
+      -- Not an active condition this update - disable without touching its filter string.
+      container:SetAuraGroupMaxFrameCount(group_key, 0)
+    end
+  end
 
-function Widget:FilterFriendlyDebuffsBySpell(db, aura, AuraFilterFunction, unit)    
-  local show_aura = 
-    db.ShowAllFriendly
-    --(db.ShowBlizzardForFriendly and (aura.nameplateShowAll or (aura.nameplateShowPersonal and aura.CastByPlayer))) or
-    or (db.ShowDispellable and aura.IsDispellable)
-    --(db.ShowBoss and aura.isBossAura) or
-    --(aura.dispelName and db.FilterByType[self.AURA_TYPE[aura.dispelName]])
+  container:SetFlowLayoutAnchorPoint(anchor_point)
+  container:SetFlowLayoutGrowthDirection(horizontal_direction, vertical_direction)
+  container:SetFlowLayoutMaximumLineSize(db_icon.Columns * (db_icon.IconWidth + db_icon.ColumnSpacing))
 
-  return show_aura
-end
+  container:SetUnit(unit.unitid)
+  container:SetEnabled(true)
 
-function Widget:FilterEnemyDebuffsBySpell(db, aura, AuraFilterFunction, unit)
-  local show_aura = 
-    db.ShowAllEnemy 
-    or (db.ShowOnlyMine and aura.CastByPlayer) 
-    or (db.ShowBlizzardForEnemy and (aura.IsImportant or aura.CastByPlayer))
+  -- AnchorTo can reference "Healthbar" (this widget's own frame) or another aura type's name
+  -- ("Buffs"/"Debuffs"/"CrowdControl", meaning "stack above/below that grid"). We cannot anchor
+  -- directly to that sibling AuraContainer's live edge: its size changes dynamically as auras are
+  -- added/removed, and addons have no OnSizeChanged access to react to that (Forbidden Aspects
+  -- block it) - the anchor would only ever reflect whatever the sibling's size happened to be at our
+  -- last update, causing overlap as it grows afterwards. Instead, anchor to Healthbar like the
+  -- sibling itself does, and add the sibling's *configured* (not live) max height to the offset, so
+  -- there's always enough room regardless of how many auras it's currently showing.
+  --
+  -- Dynamic sizing was attempted (candidateFilters-free counter via
+  -- CustomAuraContainerSharedMixin:GetAuraGroupFrameCount) but reverted: that counter reflects the
+  -- group's frame *pool* size (grows in batches, never shrinks), not the currently-displayed aura
+  -- count, so it made the reserved height "stuck at historical peak" instead of "always max" - a
+  -- different bug, not a fix. No safely addon-exposed "currently active aura count" API was found;
+  -- revisit if Blizzard ever exposes one.
+  local anchor_to_db = db.AnchorTo
+  local anchor_config = db[MODE_FOR_STYLE[unit.style]]
+  local anchor_to = widget_frame
 
-  return show_aura
-end
+  if anchor_to_db ~= "Healthbar" then
+    local sibling_icon = self.db[anchor_to_db].ModeIcon
+    local sibling_height = sibling_icon.Rows * sibling_icon.IconHeight + (sibling_icon.Rows - 1) * sibling_icon.RowSpacing
+    anchor_config = {
+      Anchor = anchor_config.Anchor,
+      InsideAnchor = anchor_config.InsideAnchor,
+      HorizontalOffset = anchor_config.HorizontalOffset,
+      VerticalOffset = (anchor_config.VerticalOffset or 0) + sibling_height,
+    }
+  end
 
-function Widget:FilterFriendlyCrowdControlBySpell(db, aura, AuraFilterFunction, unit)
-  local show_aura = 
-    db.ShowAllFriendly
-    --(db.ShowBlizzardForFriendly and (aura.nameplateShowAll or (aura.nameplateShowPersonal and aura.CastByPlayer))) or
-    or (db.ShowDispellable and aura.IsDispellable)
-    --(db.ShowBoss and aura.isBossAura)
+  AnchorFrameTo(anchor_config, container, anchor_to)
 
-  return show_aura
-end
-
-function Widget:FilterEnemyCrowdControlBySpell(db, aura, AuraFilterFunction, unit)
-  local show_aura = 
-    db.ShowAllEnemy 
-    --or (db.ShowBlizzardForEnemy and (aura.nameplateShowAll or (aura.nameplateShowPersonal and aura.CastByPlayer)))
-
-  return show_aura
-end  
-
-function Widget:FilterFriendlyBuffsBySpell(db, aura, AuraFilterFunction, unit)
-  local show_aura = 
-    db.ShowAllFriendly 
-    or (db.ShowOnFriendlyNPCs and unit.type == "NPC") 
-    or (db.ShowOnlyMine and aura.CastByPlayer)
-    -- or (db.ShowPlayerCanApply and aura.canApplyAura)
-
-  return show_aura
-end
-
-function Widget:FilterEnemyBuffsBySpell(db, aura, AuraFilterFunction, unit)
-  local show_aura = 
-    db.ShowAllEnemy 
-    or (db.ShowOnEnemyNPCs and unit.type == "NPC")
-    or (db.ShowDispellable and aura.IsDispellable)
-    -- (aura.dispelName == "Magic" and db.ShowMagic)
-
-    -- if aura.duration and db.HideUnlimitedDuration then
-
-    -- -- Checking unlimited auras after filter function results in the filter list not being able to overwrite
-    -- -- the "Show Unlimited Buffs" settings
-    -- if show_aura and (aura.duration <= 0) then
-    --   show_aura =  db.ShowUnlimitedAlways or
-    --     (db.ShowUnlimitedInCombat and unit.InCombat) or
-    --     (db.ShowUnlimitedInInstances and Addon.IsInInstance) or
-    --     (db.ShowUnlimitedOnBosses and unit.IsBossOrRare)
-    --   unit.HasUnlimitedAuras = true
-    -- end
-
-  return show_aura
+  return true
 end
 
 ---------------------------------------------------------------------------------------------------
--- Aura Sorting
+-- Auras Module / Handler
 ---------------------------------------------------------------------------------------------------
-
-local PRIORITY_FUNCTIONS = {
-  None = function(aura) return 0 end,
-  AtoZ = function(aura) return aura.name end,
-  TimeLeft = function(aura) return aura.expirationTime - GetTime() end,
-  Duration = function(aura) return aura.duration end,
-  Creation = function(aura) return aura.expirationTime - aura.duration end,
-}
-
-local function AuraSortFunctionAtoZ(a, b)
-  return a.priority < b.priority
-end
-
-local function AuraSortFunctionZtoA(a, b)
-  return a.priority > b.priority
-end
-
--- For auras without duration duration and expirationTime are 0, so sorting by TimeLeft, Duration, and Creation
--- does not work in that case. We will just sort by name for these auras
-local function AuraSortFunctionNumAscending(a, b)
-  if a.duration == 0 then
-    if b.duration == 0 then
-      return a.name < b.name
-    else
-      return false
-    end
-  elseif b.duration == 0 then
-    if a.duration == 0 then
-      return a.name < b.name
-    else
-      return true
-    end
-  else
-    return a.priority < b.priority
-  end
-end
-
-local function AuraSortFunctionNumDescending(a, b)
-  if a.duration == 0 then
-    if b.duration == 0 then
-      return a.name > b.name
-    else
-      return true
-    end
-  elseif b.duration == 0 then
-    if a.duration == 0 then
-      return a.name > b.name
-    else
-      return false
-    end
-  else
-    return a.priority > b.priority
-  end
-end
-
-local SORT_FUNCTIONS = {
-  None = nil,
-  AtoZ = {
-    Default = AuraSortFunctionAtoZ,
-    Reverse = AuraSortFunctionZtoA,
-  },
-  TimeLeft = {
-    Default = AuraSortFunctionNumAscending,
-    Reverse = AuraSortFunctionNumDescending,
-  },
-  Duration = {
-    Default = AuraSortFunctionNumAscending,
-    Reverse = AuraSortFunctionNumDescending,
-  },
-  Creation = {
-    Default = AuraSortFunctionNumAscending,
-    Reverse = AuraSortFunctionNumDescending,
-  },
-}
-
-local function SortAurasByPriority(unit_auras)
-  if #unit_auras >= 0 and SortFunction then
-    sort(unit_auras, SortFunction)
-  end
-end
-
----------------------------------------------------------------------------------------------------
--- Auras Module / Handler 
----------------------------------------------------------------------------------------------------
-
--- UnitAuraSlots: BfA - Patch 8.2.5 (2019-09-24): Added.
--- C_UnitAuras.GetAuraSlots: DF - Patch 10.2.5 (2024-01-16): Deprecated. Replaced by C_UnitAuras.GetAuraSlots.
-local function ProcessAllUnitAuras(unitid, effect)
-  -- local aura_max_display = (effect == "HARMFUL" and DEBUFF_MAX_DISPLAY) or BUFF_MAX_DISPLAY
-
-  -- -- AuraUtil.ForEachAura(unitid, effect, BUFF_MAX_DISPLAY, function(unit_aura_info)
-  -- --   unit_aura_info.duration = unit_aura_info.duration or 0
-  -- --   unit_auras[#unit_auras + 1] = unit_aura_info
-  -- --   -- Addon.Logging.Debug("Aura:", aura.name, "=> ID:", aura.spellId)
-  -- -- end, true)
-
-  -- -- AuraUtil.ForEachAura:
-  -- local continuation_token
-  -- repeat
-  --   -- continuationToken is the first return value of UnitAuraSlots
-  --   local slots = { GetAuraSlots(unitid, effect, aura_max_display, continuation_token) }
-  --   continuation_token = slots[1]
-
-  --   for i = 2, #slots do
-  --     local unit_aura_info = GetAuraDataBySlot(unitid, slots[i])  
-  --     -- Without this check, there will be a Lua error when a priest mindcontrolls another player as 
-  --     -- unit_aura_info is nil here in this case
-  --     if type(unit_aura_info) ~= nil then
-  --       --unit_aura_info.duration = unit_aura_info.duration or 0
-  --       unit_auras[#unit_auras + 1] = unit_aura_info
-
-  --       print(unit_aura_info.name, "=>", not C_UnitAuras.IsAuraFilteredOutByInstanceID(unitid, unit_aura_info.auraInstanceID, 'HARMFUL|PLAYER'))
-  --     end
-  --   end
-  -- until continuation_token == nil
-
-  -- return unit_auras
-
-  local unit_auras = {}
-  local function HandleAura(aura)
-    unit_auras[#unit_auras + 1] = aura
-    
-    aura.effect = effect
-    aura.CastByPlayer = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|PLAYER") -- aura.isFromPlayerOrPlayerPet, aura.nameplateShowPersonal
-    --aura.IsRaid = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|RAID") -- aura.isRaid
-    -- CANCELABLE, NOT_CANCELABLE
-    --aura.fd = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|INCLUDE_NAME_PLATE_ONLY") -- aura.isNameplateOnly
-    aura.IsExternalDefensive = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|EXTERNAL_DEFENSIVE")
-    aura.CrowdControl = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|CROWD_CONTROL")    
-    aura.IsRaidInCombat = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|RAID_IN_COMBAT")
-    aura.IsDispellable = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|RAID_PLAYER_DISPELLABLE")
-    aura.IsBigDefensive = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|BIG_DEFENSIVE")
-    aura.IsImportant = not IsAuraFilteredOutByInstanceID(unitid, aura.auraInstanceID, effect .. "|IMPORTANT")
-    
-    -- if aura.CastByPlayer or aura.IsRaid or aura.IsExternalDefensive or aura.CrowdControl or aura.IsRaidInCombat or
-    --   aura.IsDispellable or aura.IsBigDefensive or aura.IsImportant then
-    --   print("Aura:", aura.name, "=>", 
-    --     aura.CastByPlayer and "PLAYER" or "", 
-    --     aura.IsRaid and "RAID" or "", 
-    --     --aura.IsNameplateOnly and "NAME_PLATE_ONLY" or "", 
-    --     aura.IsExternalDefensive and "EXTERNAL_DEFENSIVE" or "", 
-    --     aura.CrowdControl and "CROWD_CONTROL" or "", 
-    --     aura.IsRaidInCombat and "RAID_IN_COMBAT" or "", 
-    --     aura.IsDispellable and "RAID_PLAYER_DISPELLABLE" or "", 
-    --     aura.IsBigDefensive and "BIG_DEFENSIVE" or "", 
-    --     aura.IsImportant and "IMPORTANT" or "")
-
-    --     print("Filter:", aura.isNameplateOnly)
-    --     -- Secret values: 
-    --     -- aura.nameplateShowAll, aura.nameplateShowPersonal
-    -- end
-  end
-
-  AuraUtil.ForEachAura(unitid, effect, nil, HandleAura, true)
-
-  return unit_auras
-end
 
 local function IgnoreAuraUpdateForUnit(widget_frame, unit)
   -- ! "Target Only" only supports the direct target, not action targets
@@ -475,7 +548,7 @@ local function IgnoreAuraUpdateForUnit(widget_frame, unit)
 
   AuraTriggerInitialize(unit)
 
-  widget_frame.HideAuras = not EnabledForStyle[unit.style] or (Widget.db.ShowTargetOnly and not unit_is_target)  
+  widget_frame.HideAuras = not EnabledForStyle[unit.style] or (Widget.db.ShowTargetOnly and not unit_is_target)
 end
 
 local function AuraGridUpdateForUnitNotNecessary(widget_frame, unit)
@@ -487,224 +560,43 @@ local function AuraGridUpdateForUnitNotNecessary(widget_frame, unit)
   end
 end
 
-local AuraGridUpdate = {
-  Buffs = false,
-  Debuffs = false,
-  CrowdControl = false,
-  --   BuffsAuraFrames = {},
-  --   DebuffsAuraFrames = {},
-  --   CrowdControlAuraFrames = {},
-  AuraFrames  ={}
-}
-
-local function FlagAuraGridForUpdate(aura_grid_update, is_crowdcontrol_aura, is_harmfull)
-  if is_crowdcontrol_aura then -- is_harmfull is true in this case
-    aura_grid_update.CrowdControl = true
-  elseif is_harmfull then
-    aura_grid_update.Debuffs = true
-  else
-    aura_grid_update.Buffs = true
-  end
-end
-
-function Widget:UNIT_AURA(unitid, update_info)
-  local widget_frame = self:GetWidgetFrameForUnit(unitid)
-  if widget_frame then 
-    widget_frame.Widget:UpdateAuras(widget_frame, widget_frame.unit)
-  end
-end
-
-function Widget:UpdateUnitAuras(aura_grid_frame, unit, enabled_auras, enabled_cc, SpellFilter, SpellFilterCC, effect, filter_mode)
-  local aura_grid = aura_grid_frame.AuraGrid
-
-  -- If auras are disabled, hide the grid and return an empty list
-  if not enabled_auras then
-    aura_grid_frame.ActiveAuras = 0
-    aura_grid_frame:Hide()
-    aura_grid:HideNonActiveAuras(aura_grid_frame)
-    return
-  end
-
-  -- Show the aura grid – it may have been hidden when the nameplate was used for a unit
-  -- type where this aura category was disabled.
-  aura_grid_frame:Show()
-
-  local db = self.db
-
-  aura_grid_frame.Filter = effect -- used for showing the correct tooltip
-  local widget_frame = aura_grid_frame:GetParent()
-  unit.HasUnlimitedAuras = false
-  local unitid = unit.unitid
-
-  local db_auras = (effect == "HARMFUL" and db.Debuffs) or db.Buffs
-  local AuraFilterFunction = self.FILTER_FUNCTIONS[filter_mode]
-  local AuraFilterFunctionCC = self.FILTER_FUNCTIONS[db.CrowdControl.FilterMode]
-
-  local unit_auras_to_show = {}
-
-  -- Can do this here as aura tiggers do not work in Midnight right now
-  if widget_frame.HideAuras then return end
-
-  local unit_auras = ProcessAllUnitAuras(unit.unitid, effect)
-  for i = 1, #unit_auras do
-    local aura = unit_auras[i]
-    local show_aura
-
-    --UnitStyle_AuraTrigger_CheckIfActive(unit, aura.spellId, aura.name, aura.CastByPlayer)
-    if aura.CrowdControl then
-      show_aura = SpellFilterCC(self, db.CrowdControl, aura, AuraFilterFunctionCC, unit)
-
-      -- Show crowd control auras that are not shown in Blizard mode as normal debuffs
-      if not show_aura and enabled_auras then
-        aura.CrowdControl = false
-        show_aura = SpellFilter(self, db_auras, aura, AuraFilterFunction, unit)
-      end
-    elseif enabled_auras then
-      show_aura = SpellFilter(self, db_auras, aura, AuraFilterFunction, unit)
-    end
-
-    if show_aura then
-      aura.unitid = unitid
-      aura.color = self:GetColorForAura(aura)
-      --aura.priority = PRIORITY_FUNCTIONS[db.SortOrder](aura)
-
-      unit_auras_to_show[#unit_auras_to_show + 1] = aura
-    end
-  end
-
-  -- Show auras
-  local aura_grid_cc = self.CrowdControl
-  local aura_grid_frame_cc = widget_frame.CrowdControl
-
-  -- Sort auras based on order criteria
---  SortAurasByPriority(unit_auras_to_show)
-
-  local aura_count = 0
-  local aura_count_cc = 0
-  for index = 1, #unit_auras_to_show do
-    local aura_frame
-    
-    local aura = unit_auras_to_show[index]
-    if aura.spellId and aura.expirationTime then
-      if aura.CrowdControl then
-        -- Don't show CCs beyond MaxAuras, sorting should be correct here
-        if aura_count_cc < aura_grid_cc.MaxAuras then
-          aura_count_cc = aura_count_cc + 1
-          aura_frame = aura_grid_cc:GetAuraFrame(aura_grid_frame_cc, aura_count_cc)
-        end
-      else
-        if aura_count < aura_grid.MaxAuras then
-          aura_count = aura_count + 1
-          aura_frame = aura_grid:GetAuraFrame(aura_grid_frame, aura_count)
-        end          
-      end
-
-      -- aura_frame is nil here when the max amount of auras is already shown
-      if aura_frame then
-        aura_frame.unitid = unitid
-        widget_frame.UnitAuras[aura.auraInstanceID] = aura_frame
-
-        aura_frame.AuraData = aura
-        -- Call function to display the aura
-        if aura.CrowdControl then
-          aura_grid_cc:UpdateAuraInformation(aura_frame)
-        else
-          aura_grid:UpdateAuraInformation(aura_frame)
-        end
-      end
-
-      -- Both aura areas (buffs/debuffs) and crowd control are filled up, no further processing necessary
-      if aura_count >= aura_grid.MaxAuras and aura_count_cc >= aura_grid_cc.MaxAuras then
-        break
-      end
-    end
-  end
-
-  -- Hide non-active aura slots
-  aura_grid_frame.ActiveAuras = aura_count
-  aura_grid:HideNonActiveAuras(aura_grid_frame, true)
-
-  if effect == "HARMFUL" then
-    aura_grid_frame_cc.ActiveAuras = aura_count_cc
-    -- If scanning debuffs, also hide non-active CC aura slots
-    aura_grid_cc:HideNonActiveAuras(aura_grid_frame_cc)
-  end
-end
-
-function Widget:UpdatePositionAuraGrid(widget_frame, aura_type, unit_style)
-  local db = self.db
-
-  local aura_grid = self[aura_type]
-  local aura_grid_frame = widget_frame[aura_type]
-  local auras_no = aura_grid_frame.ActiveAuras
-
-  -- if not aura_grid_frame.TestBackground then
-  --  aura_grid_frame.TestBackground = aura_grid_frame:CreateTexture(nil, "BACKGROUND")
-  --  aura_grid_frame.TestBackground:SetAllPoints(aura_grid_frame)
-  --  aura_grid_frame.TestBackground:SetTexture(Addon.LibSharedMedia:Fetch('statusbar', Addon.db.profile.AuraWidget.BackgroundTexture))
-  --  aura_grid_frame.TestBackground:SetVertexColor(0,0,0,0.5)
-  -- end
-
-  local db_aura_grid = db[aura_type]
-  local anchor_to_db = db_aura_grid.AnchorTo
-  local anchor_to = (anchor_to_db == "Healthbar" and aura_grid_frame:GetParent()) or widget_frame[anchor_to_db]
-
-  AnchorFrameTo(db_aura_grid[MODE_FOR_STYLE[unit_style]], aura_grid_frame, anchor_to)
-  if aura_grid.IconMode and auras_no > 0 then
-    local x_offset = 0
-    if db_aura_grid.CenterAuras then
-      -- Re-anchor the first frame, if auras should be centered
-      x_offset = (auras_no < aura_grid.Columns) and aura_grid.CenterAurasPositions[auras_no] or 0
-    end
-    local align_layout = aura_grid.AlignLayout
-    local aura_one = aura_grid_frame.AuraFrames[1]
-    aura_one:ClearAllPoints()
-    aura_one:SetPoint(align_layout[3], aura_grid_frame, (aura_grid.AuraWidgetOffset + x_offset) * align_layout[5], (aura_grid.AuraWidgetOffset + aura_grid.RowSpacing) * align_layout[6])
-  end
-
-  aura_grid_frame:SetHeight(ceil(auras_no / aura_grid.Columns) * (aura_grid.AuraHeight + aura_grid.AuraWidgetOffset) +
-    aura_grid.RowSpacing + aura_grid.AuraWidgetOffset)
+-- Wraps a plain filter string into the single-"main"-group config shape UpdateAuraContainer expects.
+local function SingleGroupConfig(filter_string, candidate_filters)
+  return filter_string and { main = { filterString = filter_string, candidateFilters = candidate_filters or {} } } or nil
 end
 
 function Widget:UpdateAurasGrids(widget_frame, unit)
   local db = self.db
+  local is_friendly = unit.reaction == "FRIENDLY"
 
-  widget_frame.UnitAuras = {}
-
-  local unitid = unit.unitid
-  widget_frame.Buffs.unitid = unitid
-  widget_frame.Debuffs.unitid = unitid
-  widget_frame.CrowdControl.unitid = unitid
-
-  local enabled_cc
-  if unit.reaction == "FRIENDLY"  then -- friendly or better
+  -- Deliberately not "is_friendly and X or Y": when X is a legitimate nil/false (e.g. no friendly
+  -- toggle matches this unit), that idiom falls through to Y - the *other* reaction's settings -
+  -- instead of correctly yielding "nothing to show" for this reaction.
+  local buffs_configs, debuffs_configs, enabled_cc
+  if is_friendly then
+    buffs_configs = db.Buffs.ShowFriendly and GetFriendlyBuffsGroupConfigs(db.Buffs, unit)
+    debuffs_configs = db.Debuffs.ShowFriendly and GetFriendlyDebuffsGroupConfigs(db.Debuffs)
     enabled_cc = db.CrowdControl.ShowFriendly
-    
-    local buff_aura_grid = (db.SwitchAreaByReaction and widget_frame.Debuffs) or widget_frame.Buffs
-    local debuff_aura_grid = (db.SwitchAreaByReaction and widget_frame.Buffs) or widget_frame.Debuffs        
-    
-    self:UpdateUnitAuras(buff_aura_grid, unit, db.Buffs.ShowFriendly, false, self.FilterFriendlyBuffsBySpell, self.FilterFriendlyCrowdControlBySpell, "HELPFUL", db.Buffs.FilterMode)
-    self:UpdateUnitAuras(debuff_aura_grid, unit, db.Debuffs.ShowFriendly, enabled_cc, self.FilterFriendlyDebuffsBySpell, self.FilterFriendlyCrowdControlBySpell, "HARMFUL", db.Debuffs.FilterMode)
   else
+    buffs_configs = db.Buffs.ShowEnemy and GetEnemyBuffsGroupConfigs(db.Buffs, unit)
+    debuffs_configs = db.Debuffs.ShowEnemy and GetEnemyDebuffsGroupConfigs(db.Debuffs)
     enabled_cc = db.CrowdControl.ShowEnemy
-    
-    self:UpdateUnitAuras(widget_frame.Buffs, unit, db.Buffs.ShowEnemy, false, self.FilterEnemyBuffsBySpell, self.FilterEnemyCrowdControlBySpell, "HELPFUL", db.Buffs.FilterMode)
-    self:UpdateUnitAuras(widget_frame.Debuffs, unit, db.Debuffs.ShowEnemy, enabled_cc, self.FilterEnemyDebuffsBySpell, self.FilterEnemyCrowdControlBySpell, "HARMFUL", db.Debuffs.FilterMode)
+  end
+  local cc_configs = enabled_cc and SingleGroupConfig(GetCrowdControlFilterString(db.CrowdControl, is_friendly))
+
+  local buffs_active = self:UpdateAuraContainer(widget_frame, "Buffs", buffs_configs, unit)
+  local debuffs_active = self:UpdateAuraContainer(widget_frame, "Debuffs", debuffs_configs, unit)
+  local cc_active = self:UpdateAuraContainer(widget_frame, "CrowdControl", cc_configs, unit)
+
+  if AuraGridUpdateForUnitNotNecessary(widget_frame, unit) then
+    for _, aura_type in ipairs(AURA_CONTAINER_TYPES) do
+      local container = widget_frame[aura_type .. "AuraContainer"]
+      if container then container:SetEnabled(false) end
+    end
+    return
   end
 
-  if AuraGridUpdateForUnitNotNecessary(widget_frame, unit) then return end
-
-  if widget_frame.Buffs.ActiveAuras > 0 or widget_frame.Debuffs.ActiveAuras > 0 or widget_frame.CrowdControl.ActiveAuras > 0 then
-    self:UpdatePositionAuraGrid(widget_frame, "Buffs", unit.style)
-    self:UpdatePositionAuraGrid(widget_frame, "Debuffs", unit.style)
-
-    if enabled_cc then
-      self:UpdatePositionAuraGrid(widget_frame, "CrowdControl", unit.style)
-      widget_frame.CrowdControl:Show()
-    else
-      widget_frame.CrowdControl:Hide()
-    end
-
+  if buffs_active or debuffs_active or cc_active then
     widget_frame:Show()
   else
     widget_frame:Hide()
@@ -712,83 +604,68 @@ function Widget:UpdateAurasGrids(widget_frame, unit)
 end
 
 function Widget:UpdateAuras(widget_frame, unit)
-  if not IgnoreAuraUpdateForUnit(widget_frame, unit) then 
+  if not IgnoreAuraUpdateForUnit(widget_frame, unit) then
     self:UpdateAurasGrids(widget_frame, unit)
   end
 end
 
 ---------------------------------------------------------------------------------------------------
--- Creation and update functions
+-- Widget functions for creation and update
 ---------------------------------------------------------------------------------------------------
 
-local function OnUpdateAuraGridFrame(self, elapsed)
-  -- Update the number of seconds since the last update
-  self.TimeSinceLastUpdate = self.TimeSinceLastUpdate + elapsed
+function Widget:Create(tp_frame)
+  -- Required Widget Code
+  local widget_frame = _G.CreateFrame("Frame", nil, tp_frame)
+  widget_frame:Hide()
 
-  if self.TimeSinceLastUpdate >= self.AuraGrid.UpdateInterval then
-    self.TimeSinceLastUpdate = 0
+  -- Custom Code
+  --------------------------------------
+  widget_frame:SetAllPoints(tp_frame)
 
-    local aura_frame
-    for i = 1, self.ActiveAuras do
-      aura_frame = self.AuraFrames[i]
-      self.AuraGrid:UpdateWidgetTime(aura_frame, aura_frame.AuraData.expirationTime, aura_frame.AuraData.duration)
+  for _, aura_type in ipairs(AURA_CONTAINER_TYPES) do
+    local container = AcquireAuraContainer(aura_type)
+    if container then
+      container:SetParent(widget_frame)
+      container:SetEnabled(false)
+      widget_frame[aura_type .. "AuraContainer"] = container
     end
+  end
+
+  widget_frame.Widget = self
+
+  self:UpdateLayout(widget_frame)
+  --------------------------------------
+  -- End Custom Code
+
+  return widget_frame
+end
+
+function Widget:IsEnabled()
+  self.db = Addon.db.profile.AuraWidget
+  return self.db.ON or self.db.ShowInHeadlineView
+end
+
+function Widget:OnEnable()
+  self:SubscribeEvent("PLAYER_TARGET_CHANGED")
+  self:SubscribeEvent("PLAYER_REGEN_ENABLED")
+  self:SubscribeEvent("PLAYER_REGEN_DISABLED")
+
+  PreallocateAuraContainers()
+end
+
+function Widget:EnabledForStyle(style, unit)
+  if (style == "NameOnly" or style == "NameOnly-Unique") then
+    return self.db.ShowInHeadlineView or Addon.ActiveAuraTriggers
+  elseif style ~= "etotem" then
+    return self.db.ON or Addon.ActiveAuraTriggers
   end
 end
 
-function Widget:UpdateAuraGridLayout(widget_frame, aura_type)
-  local aura_grid = self[aura_type]
-  local aura_grid_frame = widget_frame[aura_type]
-  local aura_frame_list = aura_grid_frame.AuraFrames
-
-  local no_auras = #aura_frame_list
-
-  -- If the number of auras to show was decreased, remove any overflow aura frames
-  if no_auras > aura_grid.MaxAuras then
-    for i = no_auras, aura_grid.MaxAuras + 1, -1 do
-      aura_frame_list[i]:Hide()
-      aura_frame_list[i] = nil
-    end
-    no_auras = aura_grid.MaxAuras
-  end
-
-  -- When called from Create(), #aura_frame_list is 0, so nothing will be done here
-  -- When called from after a settings update, delete aura frames with wrong layout (icon/bar mode) and update all other aura frames
-  local icon_mode = aura_grid.IconMode
-  local aura_frame
-  for i = no_auras, 1, -1 do
-    aura_frame = aura_frame_list[i]
-    if icon_mode then
-      if aura_frame.Border then
-        aura_grid:UpdateAuraFramePosition(aura_frame_list, aura_grid_frame, aura_frame, i)
-        aura_grid:UpdateAuraFrame(aura_frame)
-      else
-        aura_frame:Hide()
-        aura_frame_list[i] = nil
-      end
-    else
-      if aura_frame.Statusbar then
-        aura_grid:UpdateAuraFramePosition(aura_frame_list, aura_grid_frame, aura_frame, i)
-        aura_grid:UpdateAuraFrame(aura_frame)
-      else
-        aura_frame:Hide()
-        aura_frame_list[i] = nil
-      end
-    end
-  end
-
-  aura_grid_frame:SetSize(aura_grid.AuraWidgetWidth, aura_grid.AuraWidgetHeight)
-
-  if ShowDuration or not aura_grid.IconMode then
-    aura_grid_frame:SetScript("OnUpdate", OnUpdateAuraGridFrame)
-  else
-    aura_grid_frame:SetScript("OnUpdate", nil)
-  end
-
-  aura_grid_frame:SetFrameLevel(widget_frame:GetFrameLevel())
+function Widget:OnUnitAdded(widget_frame, unit)
+  self:UpdateAuras(widget_frame, unit)
 end
 
--- Initialize the aura grid layout, don't update auras themselves as not unitid know at this point
+-- Initialize the aura container layout, don't update auras themselves as not unitid know at this point
 function Widget:UpdateLayout(widget_frame)
   local frame_level
   if self.db.FrameOrder == "HEALTHBAR_AURAS" then
@@ -798,15 +675,12 @@ function Widget:UpdateLayout(widget_frame)
   end
   widget_frame:SetFrameLevel(frame_level)
 
-  -- ClearAllPoints here as otherwise Lua errors might occur if the old anchoring and the new anchoring
-  -- are cyclic temporarily
-  widget_frame.Buffs:ClearAllPoints()
-  widget_frame.Debuffs:ClearAllPoints()
-  widget_frame.CrowdControl:ClearAllPoints()
-  
-  self:UpdateAuraGridLayout(widget_frame, "Buffs")
-  self:UpdateAuraGridLayout(widget_frame, "Debuffs")
-  self:UpdateAuraGridLayout(widget_frame, "CrowdControl")
+  for _, aura_type in ipairs(AURA_CONTAINER_TYPES) do
+    local container = widget_frame[aura_type .. "AuraContainer"]
+    if container then
+      container:SetFrameLevel(frame_level)
+    end
+  end
 end
 
 function Widget:PLAYER_TARGET_CHANGED()
@@ -827,793 +701,22 @@ function Widget:PLAYER_TARGET_CHANGED()
   end
 end
 
-
 function Widget:PLAYER_REGEN_ENABLED()
-  -- It seems that unitid here can be nil when using the healthstone while in combat
-  -- assert (unit.unitid ~= nil, "Auras: PLAYER_REGEN_ENABLED - unitid =", unit.unitid)
-
-  for unitid, tp_frame in Addon:GetActiveThreatPlates() do
-    local widget_frame = tp_frame.widgets.Auras
-    if widget_frame then 
-      local unit = tp_frame.unit
-      if unit.HasUnlimitedAuras then
-        self:UpdateAuras(widget_frame, unit)
-      end
-    end
-  end
+  -- Retries pool creation if the widget was first enabled mid-combat (e.g. /reload during a fight),
+  -- so the AuraContainer pools never got a chance to be created. No-op once the pools already exist.
+  -- Also fires (harmlessly, InCombatLockdown() guards it) on the aliased PLAYER_REGEN_DISABLED.
+  PreallocateAuraContainers()
 end
 
 Widget.PLAYER_REGEN_DISABLED = Widget.PLAYER_REGEN_ENABLED
-
----------------------------------------------------------------------------------------------------
--- Auras Area
----------------------------------------------------------------------------------------------------
-
-local function CreateAuraGrid(self, parent)
-  local aura_grid_frame = _G.CreateFrame("Frame", nil, parent)
-  aura_grid_frame.AuraFrames = {}
-  aura_grid_frame.ActiveAuras = 0
-  aura_grid_frame.AuraGrid = self
-
-  return aura_grid_frame
-end
-
-local function HideNonActiveAuras(self, aura_grid_frame, stop_highlight)
-  local aura_frames = aura_grid_frame.AuraFrames
-  for i = aura_grid_frame.ActiveAuras + 1, #aura_frames do
-    aura_frames[i]:Hide()
-    if stop_highlight then
-      AuraHighlightStop(aura_frames[i].Highlight)
-    end
-  end
-end
-
-local function UpdateAuraFramePosition(self, aura_frame_list, aura_grid_frame, aura_frame, no)
-  local align_layout = self.AlignLayout
-  aura_frame:ClearAllPoints()
-  if no == 1 then
-    aura_frame:SetPoint(align_layout[3], aura_grid_frame, self.AuraWidgetOffset * align_layout[5], (self.AuraWidgetOffset + self.RowSpacing) * align_layout[6])
-  elseif (no - 1) % self.Columns == 0 then
-    aura_frame:SetPoint(align_layout[3], aura_frame_list[no - self.Columns], align_layout[4], 0, self.RowSpacing * align_layout[6])
-  else
-    aura_frame:SetPoint(align_layout[1], aura_frame_list[no - 1], align_layout[2], self.ColumnSpacing * align_layout[5], 0)
-  end
-end
-
-local function GetAuraFrame(self, aura_grid_frame, no)
-  local aura_frame_list = aura_grid_frame.AuraFrames
-
-  local aura_frame = aura_frame_list[no]
-  if aura_frame == nil then
-    -- Should always be #aura_frame_list + 1
-    aura_frame = self:CreateAuraFrame(aura_grid_frame)
-
-    self:UpdateAuraFramePosition(aura_frame_list, aura_grid_frame, aura_frame, no)
-    self:UpdateAuraFrame(aura_frame)
-
-    aura_frame_list[no] = aura_frame
-  end
-
-  return aura_frame
-end
-
----------------------------------------------------------------------------------------------------
--- Functions for the aura grid with icons
----------------------------------------------------------------------------------------------------
-
-local function CreateAuraFrameIconMode(self, parent)
-  local frame = _G.CreateFrame("Frame", nil, parent)
-  frame:SetFrameLevel(parent:GetFrameLevel())
-
-  frame.Icon = frame:CreateTexture(nil, "ARTWORK", nil, -5)
-  frame.Border = _G.CreateFrame("Frame", nil, frame, BackdropTemplate)
-  frame.Border:SetFrameLevel(parent:GetFrameLevel())
-  frame.Cooldown = Addon.CreateCooldown(frame, HideOmniCC)
-
-  frame.Highlight = _G.CreateFrame("Frame", nil, frame)
-  frame.Highlight:SetFrameLevel(parent:GetFrameLevel())
-  frame.Highlight:SetPoint("CENTER")
-
-  -- Use a seperate frame for text elements as a) using frame as parent results in the text being shown below
-  -- the cooldown frame and b) using the cooldown frame results in the text not being visible if there is no
-  -- cooldown (i.e., duration and expiration are nil which is true for auras with unlimited duration)
-  local text_frame = _G.CreateFrame("Frame", nil, frame)
-  text_frame:SetFrameLevel(parent:GetFrameLevel())
-  text_frame:SetAllPoints(frame.Icon)
-  frame.Stacks = text_frame:CreateFontString(nil, "OVERLAY")
-  frame.TimeLeft = text_frame:CreateFontString(nil, "OVERLAY")
-
-  frame:Hide()
-
-  return frame
-end
-
-local function UpdateAuraFrameIconMode(self, frame)
-  local db = self.db_widget
-
-  frame.Cooldown:SetShownSwipe(db.ShowCooldownSpiral, HideOmniCC)
-  if ShowDuration then
-    frame.TimeLeft:Show()
-  else
-    frame.TimeLeft:Hide()
-  end
-
-  -- Add tooltips to icons
-
-  if db.ShowTooltips then
-    frame:SetScript("OnEnter", AuraFrameOnEnter)
-    frame:SetScript("OnLeave", AuraFrameOnLeave)
-  else
-    frame:SetScript("OnEnter", nil)
-    frame:SetScript("OnLeave", nil)
-  end
-  -- Setting the OnEnter/Leave, OnMouseDown/Up script automatically implies EnableMouse(true)
-  -- And with that, right clicking and moving the camera does not work anymore when hovering over an aura.
-  frame:EnableMouse(false)
-  frame:SetMouseMotionEnabled(true)
-
-  db = self.db
-
-  -- Icon
-  frame:SetSize(db.IconWidth, db.IconHeight)
-  frame.Icon:SetAllPoints(frame)
-  --frame.Icon:SetTexCoord(.07, 1-.07, .23, 1-.23) -- Style: Widee
-  frame.Icon:SetTexCoord(.10, 1-.07, .12, 1-.12)  -- Style: Square - remove border from icons
-
-  if db.ShowBorder then
-    local offset, edge_size, inset = 2, 8, 0
-    frame.Border:ClearAllPoints()
-    frame.Border:SetPoint("TOPLEFT", frame, "TOPLEFT", -offset, offset)
-    frame.Border:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", offset, -offset)
-    frame.Border:SetBackdrop({
-      edgeFile = Widget.TEXTURE_BORDER,
-      edgeSize = edge_size,
-      insets = { left = inset, right = inset, top = inset, bottom = inset },
-    })
-    frame.Border:SetBackdropBorderColor(0, 0, 0, 1)
-    frame.Border:Show()
-
-  else
-    frame.Border:Hide()
-  end
-
-  AuraHighlightStopPrevious(frame.Highlight)
-  if AuraHighlightEnabled then
-    frame.Highlight:SetSize(frame:GetWidth() + AuraHighlightOffset, frame:GetHeight() + AuraHighlightOffset)
-  end
-
-  FontUpdateText(frame, frame.TimeLeft, db.Duration)
-  FontUpdateText(frame, frame.Stacks, db.StackCount)
-end
-
-local function UpdateAuraInformationIconMode(self, aura_frame) -- texture, duration, expiration, stacks, color, name)
-  local duration = aura_frame.AuraData.duration
-  local expiration = aura_frame.AuraData.expirationTime
-  local stacks = aura_frame.AuraData.applications
-  local color = aura_frame.AuraData.color
-  
-  -- Expiration
-  self:UpdateWidgetTime(aura_frame, expiration, duration)
-
-  local db_widget = self.db_widget
-  if db_widget.ShowStackCount then
-    local stacks = GetAuraApplicationDisplayCount(aura_frame.unitid, aura_frame.AuraData.auraInstanceID)
-    aura_frame.Stacks:SetText(stacks)
-    aura_frame.Stacks:Show()
-  else
-    aura_frame.Stacks:Hide()
-  end
-
-  aura_frame.Icon:SetTexture(aura_frame.AuraData.icon)
-
-  -- Highlight Coloring
-  if self.db.ShowBorder then
-    if db_widget.ShowAuraType then
-      aura_frame.Border:SetBackdropBorderColor(color.r, color.g, color.b, 1)
-    end
-  end
-
-  if not IsSecretValueTP(duration) then
-    if AuraHighlightEnabled then
-      if aura_frame.AuraData.isStealable then
-        AuraHighlightStart(aura_frame.Highlight, AuraHighlightColor, 0)
-      else
-        AuraHighlightStop(aura_frame.Highlight)
-      end
-    end
-    
-    aura_frame.Cooldown:Set(expiration - duration, duration + .25)
-    AnimationStopFlash(aura_frame)
-  end
-  
-  aura_frame:Show()
-end
-
--- local AbbrevOptions = {
---    breakpointData= {
---       {breakpoint = 3600, fractionDivisor = 3600, significandDivisor = 1/1, abbreviation = "", abbreviationIsGlobal = false}, 
---       {breakpoint = 60, fractionDivisor = 60, significandDivisor = 1/1, abbreviation = "", abbreviationIsGlobal = false},
---       {breakpoint = 0, fractionDivisor = 1, significandDivisor = 1/1, abbreviation = "", abbreviationIsGlobal = false}
--- }}
-
--- local AbbrevOptionsUnit = {
---    breakpointData= {
---       {breakpoint = 3600, fractionDivisor = 3600, significandDivisor = 1/1, abbreviation = "h", abbreviationIsGlobal = false}, 
---       {breakpoint = 60, fractionDivisor = 60, significandDivisor = 1/1, abbreviation = "m", abbreviationIsGlobal = false},
---       {breakpoint = 0, fractionDivisor = 1, significandDivisor = 1/1, abbreviation = "", abbreviationIsGlobal = false}
--- }}
-
--- local function GetAbbreviatedTime(seconds)
---   return AbbreviateNumbers(seconds, AbbrevOptions)
--- end
-
--- local TimeFormatter = CreateFromMixins(SecondsFormatterMixin)
--- TimeFormatter:Init(0, SecondsFormatter.Abbreviation.OneLetter, false, true)
--- TimeFormatter:Init(
---   SecondsFormatterConstants.ZeroApproximationThreshold,
---   SecondsFormatter.Abbreviation.OneLetter,
---   SecondsFormatterConstants.DontRoundUpLastUnit,
---   SecondsFormatterConstants.ConvertToLower,
---   SecondsFormatterConstants.RoundUpIntervals)
--- TimeFormatter:SetDesiredUnitCount(1)
--- TimeFormatter:SetMinInterval(SecondsFormatter.Interval.Minutes)
--- TimeFormatter:SetStripIntervalWhitespace(true)
-
-local function UpdateWidgetTimeIconMode(self, aura_frame, expiration, duration)
-  local timeleft = GetAuraDuration(aura_frame:GetParent().unitid, aura_frame.AuraData.auraInstanceID)
-  if timeleft then
-    aura_frame.TimeLeft:SetAlphaFromBoolean(timeleft:IsZero(), 0, 1)
-    -- -- "%.1f"    
-    aura_frame.TimeLeft:SetFormattedText("%d", timeleft:GetRemainingDuration())
-
-    -- Unit is hostile and debuff - short duration format
-    -- if (Addon.GetUnitReactionToPlayer(unitid) < 5) and aura_frame.isHarmful then
-    -- -- "%.1f"    
-    --   aura_frame.TimeLeft:SetFormattedText("%d", timeleft:GetRemainingDuration())
-    -- else
-    --   aura_frame.TimeLeft:SetText(TimeFormatter:Format(timeleft:GetRemainingDuration(), false, true))
-    -- end
-
-    aura_frame.Cooldown:SetCooldownFromDurationObject(timeleft)
-  else
-    aura_frame.TimeLeft:SetText()
-  end
-
-  -- AnimationStopFlash(aura_frame)
-  -- local db_widget = self.db_widget
-  -- if db_widget.FlashWhenExpiring and timeleft < db_widget.FlashTime then
-  --   AnimationFlash(aura_frame)
-  -- end
-end
-
----------------------------------------------------------------------------------------------------
--- Functions for the aura grid with bars
----------------------------------------------------------------------------------------------------
-
-local function CreateAuraFrameBarMode(self, parent)
-  local db = self.db
-  local font = Addon.LibSharedMedia:Fetch('font', db.Font)
-
-  -- frame is probably not necessary, should be ok do add everything to the statusbar frame
-  local frame = _G.CreateFrame("Frame", nil, parent)
-  frame:SetFrameLevel(parent:GetFrameLevel())
-
-  frame.Statusbar = _G.CreateFrame("StatusBar", nil, frame)
-  frame.Statusbar:SetFrameLevel(parent:GetFrameLevel())
-
-  frame.Background = frame.Statusbar:CreateTexture(nil, "BACKGROUND", nil, 0)
-  frame.Background:SetAllPoints()
-
-  frame.Highlight = _G.CreateFrame("Frame", nil, frame)
-  frame.Highlight:SetFrameLevel(parent:GetFrameLevel())
-
-  frame.Icon = frame:CreateTexture(nil, "ARTWORK", nil, -5)
-
-  frame.Stacks = frame.Statusbar:CreateFontString(nil, "OVERLAY")
-  frame.Stacks:SetAllPoints(frame.Icon)
-  --frame.Stacks:SetFont("Fonts\\FRIZQT__.TTF", 11)
-
-  frame.LabelText = frame.Statusbar:CreateFontString(nil, "OVERLAY")
-  frame.LabelText:SetAllPoints(frame.Statusbar)
-  frame.TimeText = frame.Statusbar:CreateFontString(nil, "OVERLAY")
-  frame.TimeText:SetAllPoints(frame.Statusbar)
-
-  frame.Cooldown = Addon.CreateCooldown(frame, HideOmniCC)
-
-  frame:Hide()
-
-  return frame
-end
-
-local function UpdateAuraFrameBarMode(self, frame)
-  local db = self.db_widget
-
-  frame.Cooldown:SetShownSwipe(db.ShowCooldownSpiral, HideOmniCC)
-  if ShowDuration then
-    frame.TimeText:Show()
-  else
-    frame.TimeText:Hide()
-  end
-
-  -- Add tooltips to icons
-  if db.ShowTooltips then
-    frame:SetScript("OnEnter", AuraFrameOnEnter)
-    frame:SetScript("OnLeave", AuraFrameOnLeave)
-  else
-    frame:SetScript("OnEnter", nil)
-    frame:SetScript("OnLeave", nil)
-  end
-  -- Setting the OnEnter/Leave, OnMouseDown/Up script automatically implies EnableMouse(true)
-  -- And with that, right clicking and moving the camera does not work anymore when hovering over an aura.
-  frame:EnableMouse(false)
-  frame:SetMouseMotionEnabled(true)
-
-  db = self.db
-  local font = Addon.LibSharedMedia:Fetch('font', db.Font)
-
-  -- width and position calculations
-  local frame_width = db.BarWidth
-  if db.ShowIcon then
-    frame_width = frame_width + db.BarHeight + db.IconSpacing
-  end
-  frame:SetSize(frame_width, db.BarHeight)
-
-  frame.Background:SetTexture(Addon.LibSharedMedia:Fetch('statusbar', db.BackgroundTexture))
-  frame.Background:SetVertexColor(db.BackgroundColor.r, db.BackgroundColor.g, db.BackgroundColor.b, db.BackgroundColor.a)
-
-  frame.Icon:ClearAllPoints()
-  frame.Statusbar:ClearAllPoints()
-
-  if db.ShowIcon then
-    if db.IconAlignmentLeft then
-      frame.Icon:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 0, 0)
-      frame.Statusbar:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", db.BarHeight + db.IconSpacing, 0)
-    else
-      frame.Icon:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", db.BarWidth + db.IconSpacing, 0)
-      frame.Statusbar:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 0, 0)
-    end
-
-    FontUpdateText(frame.Icon, frame.Stacks, db.StackCount)
-
-    frame.Icon:SetTexCoord(0, 1, 0, 1)
-    frame.Icon:SetSize(db.BarHeight, db.BarHeight)
-    frame.Icon:Show()
-  else
-    frame.Statusbar:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 0, 0)
-    frame.Icon:Hide()
-  end
-
-  FontUpdateText(frame.Statusbar, frame.LabelText, db.Label)
-  FontUpdateText(frame.Statusbar, frame.TimeText, db.Duration)
-
-  AuraHighlightStopPrevious(frame.Highlight)
-  if AuraHighlightEnabled then
-    local aura_highlight = frame.Highlight
-
-    aura_highlight:ClearAllPoints()
-    if self.db_widget.Highlight.Type == "ActionButton" then
-      -- Align to icon because of bad scaling otherwise
-      local offset = - (AuraHighlightOffset * 0.5)
-      if db.IconAlignmentLeft then
-        aura_highlight:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", offset, offset)
-      else
-        aura_highlight:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", db.BarWidth + db.IconSpacing + offset, offset)
-      end
-      aura_highlight:SetSize(db.BarHeight + AuraHighlightOffset, db.BarHeight + AuraHighlightOffset)
-    else
-      aura_highlight:SetPoint("CENTER")
-      aura_highlight:SetSize(frame:GetWidth() + AuraHighlightOffset, frame:GetHeight() + AuraHighlightOffset)
-    end
-  end
-
-  frame.Statusbar:SetSize(db.BarWidth, db.BarHeight)
-  frame.Statusbar:SetStatusBarTexture(Addon.LibSharedMedia:Fetch('statusbar', db.Texture))
-  frame.Statusbar:GetStatusBarTexture():SetHorizTile(false)
-  frame.Statusbar:GetStatusBarTexture():SetVertTile(false)
-end
-
-local function UpdateAuraInformationBarMode(self, aura_frame) -- texture, duration, expiration, stacks, color, name)
-  local db = self.db
-
-  local duration = aura_frame.AuraData.duration
-  local expiration = aura_frame.AuraData.expirationTime
-  local stacks = aura_frame.AuraData.applications
-  local color = aura_frame.AuraData.color
-
-  if self.db_widget.ShowStackCount then
-    local stacks = GetAuraApplicationDisplayCount(aura_frame.unitid, aura_frame.AuraData.auraInstanceID)
-    
-     -- Stacks are either shown on the icon or as postfix to the aura name when
-    -- a) OmniCC is enabled (which shows the CD on the icon) or the icon is disabled
-    if not db.ShowIcon or not HideOmniCC then
-      aura_frame.Stacks:Hide()
-      aura_frame.AuraData.name = aura_frame.AuraData.name .. " (" .. stacks .. ")"
-    else
-      aura_frame.Stacks:SetText(stacks)
-      aura_frame.Stacks:Show()
-    end
-  else
-    aura_frame.Stacks:Hide()
-  end
-
-  -- Icon
-  if db.ShowIcon then
-    aura_frame.Icon:SetTexture(aura_frame.AuraData.icon)
-  end
-
-  if not IsSecretValueTP(duration) then
-    -- if AuraHighlightEnabled then
-    --   if aura_frame.AuraData.isStealable then
-    --     AuraHighlightStart(aura_frame.Highlight, AuraHighlightColor, 0)
-    --   else
-    --     AuraHighlightStop(aura_frame.Highlight)
-    --   end
-    -- end
-
-    aura_frame.Cooldown:Set(duration, expiration)
-    AnimationStopFlash(aura_frame)
-  end
-
-  aura_frame.LabelText:SetText(aura_frame.AuraData.name)
-  aura_frame.Statusbar:SetStatusBarColor(color.r, color.g, color.b, color.a or 1)
-
-  self:UpdateWidgetTime(aura_frame, expiration, duration)
-
-  aura_frame:Show()
-end
-
-local function UpdateWidgetTimeBarMode(self, aura_frame, expiration, duration)
-  local timeleft = GetAuraDuration(aura_frame.unitid, aura_frame.AuraData.auraInstanceID)
-  if timeleft then
-    aura_frame.TimeText:SetAlphaFromBoolean(timeleft:IsZero(), 0, 1)
-    aura_frame.TimeText:SetFormattedText("%d", timeleft:GetRemainingDuration())
-    aura_frame.Cooldown:SetCooldownFromDurationObject(timeleft)
-  
-    aura_frame.Statusbar:SetTimerDuration(timeleft, AuraBarInterpolation, RemainingTimeDirection)
-
-    local color = aura_frame.AuraData.color
-    local bg_color = self.db.BackgroundColor
-    
-    local color = EvaluateColorValueFromBoolean(timeleft:IsZero(), color, bg_color)
-
-    aura_frame.Background:SetVertexColor(color:GetRGBA())
-  else
-    aura_frame.TimeText:SetText()
-  end
-
-  -- if timeleft then
-  --   aura_frame.TimeText:SetAlphaFromBoolean(timeleft:IsZero(), 0, 1)
-
-  --   if timeleft:GetTotalDuration() == 0 then
-  --     aura_frame.Statusbar:SetValue(100)
-  --     --AnimationStopFlash(aura_frame)
-  --   -- elseif expiration == 0 then
-  --   --   aura_frame.TimeText:SetText("")
-  --   --   aura_frame.Statusbar:SetValue(0)
-  --     --AnimationStopFlash(aura_frame)
-  --   else
-  --     local db = self.db_widget
-     
-
-      -- if db.FlashWhenExpiring and timeleft < db.FlashTime then
-      --   AnimationFlash(aura_frame)
-      -- end
-
-  --     aura_frame.Statusbar:SetTimerDuration(timeleft, 0)
-  --   end
-  -- else
-  --   aura_frame.TimeText:SetText()
-  -- end
-end
-
-local function UpdateWidgetTimeBarModeNoDuration(self, aura_frame, expiration, duration)
-  if duration == 0 then
-    aura_frame.Statusbar:SetValue(100)
-    --AnimationStopFlash(aura_frame)
-  elseif expiration == 0 then
-    aura_frame.Statusbar:SetValue(0)
-    --AnimationStopFlash(aura_frame)
-  else
-    local timeleft = expiration - GetTime()
-    if timeleft > 60 then
-      aura_frame.TimeText:SetText(floor(timeleft/60).."m")
-    else
-      aura_frame.TimeText:SetText(floor(timeleft))
-    end
-
-    local db = self.db_widget
-    if db.FlashWhenExpiring and timeleft < db.FlashTime then
-      AnimationFlash(aura_frame)
-    end
-
-    aura_frame.Statusbar:SetValue(timeleft * 100 / duration)
-  end
-end
-
----------------------------------------------------------------------------------------------------
---    if frame and frame.Active then
---      local widget_frame = frame.widgets.Auras
---      local unit = frame.unit
---
---      if widget_frame.Active and unit.HasUnlimitedAuras then
---        unit.InCombat = _G.UnitAffectingCombat(unit.unitid)
---        self:UpdateIconGrid(widget_frame, unit)
---      end
---    end
---  end
---end
--- Widget functions for creation and update
----------------------------------------------------------------------------------------------------
-
-function Widget:Create(tp_frame)
-  -- Required Widget Code
-  local widget_frame = _G.CreateFrame("Frame", nil, tp_frame)
-  widget_frame:Hide()
-
-  -- Custom Code
-  --------------------------------------
-  widget_frame:SetAllPoints(tp_frame)
-
-  widget_frame.Buffs = self.Buffs:Create(widget_frame)
-  widget_frame.Debuffs = self.Debuffs:Create(widget_frame)
-  widget_frame.CrowdControl = self.CrowdControl:Create(widget_frame)
-
-  widget_frame.Widget = self
-
-  self:UpdateLayout(widget_frame)
-
-  widget_frame:HookScript("OnShow", OnShowHookScript)
-  -- widget_frame:HookScript("OnHide", OnHideHookScript)
-  --------------------------------------
-  -- End Custom Code
-
-  return widget_frame
-end
-
-function Widget:IsEnabled()
-  self.db = Addon.db.profile.AuraWidget
-  return self.db.ON or self.db.ShowInHeadlineView
-end
-
-function Widget:OnEnable()
-  self:SubscribeEvent("PLAYER_TARGET_CHANGED")
-  self:SubscribeEvent("PLAYER_REGEN_ENABLED")
-  self:SubscribeEvent("PLAYER_REGEN_DISABLED")
-  self:SubscribeEvent("UNIT_AURA")
-  -- LOSS_OF_CONTROL_ADDED
-  -- LOSS_OF_CONTROL_UPDATE
-end
-
-function Widget:EnabledForStyle(style, unit)
-  if (style == "NameOnly" or style == "NameOnly-Unique") then
-    return self.db.ShowInHeadlineView or Addon.ActiveAuraTriggers
-  elseif style ~= "etotem" then
-    return self.db.ON or Addon.ActiveAuraTriggers
-  end
-end
-
-function Widget:OnUnitAdded(widget_frame, unit)
-  self:UpdateAuras(widget_frame, unit)
-end
-
--- function Widget:OnUnitRemoved(widget_frame, unit)
--- end
-
-local function ParseFilter(filter_by_spell)
-  local filter = {}
-  local only_player_auras = true
-
-  local modifier, spell
-  for key, value in pairs(filter_by_spell) do
-    -- remove comments and whitespaces from the filter (string)
-    local pos = value:find("%-%-")
-    if pos then value = value:sub(1, pos - 1) end
-    value = value:match("^%s*(.-)%s*$")  -- remove any leading/trailing whitespaces from the line
-
-    -- value:match("^%s*(%w+)%s*(.-)%s*$")  -- remove any leading/trailing whitespaces from the line
-    if value:sub(1, 4) == "All " then
-      modifier = "All"
-      spell = value:match("^All%s*(.-)$")
-      only_player_auras = false
-    elseif value:sub(1, 3) == "My " then
-      modifier = "My"
-      spell = value:match("^My%s*(.-)$")
-    elseif value:sub(1, 4) == "Not " then
-      modifier = "Not"
-      spell = value:match("^Not%s*(.-)$")
-      only_player_auras = false
-    else
-      modifier = true
-      spell = value
-    end
-
-    -- separete filter by name and ID for more efficient aura filtering
-    local spell_no = tonumber(spell)
-    if spell_no then
-      filter[spell_no] = modifier
-    elseif spell ~= '' then
-      filter[spell] = modifier
-    end
-  end
-
-  return filter
-end
-
-function Widget:ParseSpellFilters()
-  self.db = Addon.db.profile.AuraWidget
-
-  self.AuraFilterBuffs = ParseFilter(self.db.Buffs.FilterBySpell)
-  self.AuraFilterDebuffs = ParseFilter(self.db.Debuffs.FilterBySpell)
-  self.AuraFilterCrowdControl = ParseFilter(self.db.CrowdControl.FilterBySpell)
-end
-
--- function Widget:UpdateSizeDataIconMode(aura_grid, db)
---   aura_grid.AuraWidth = db.IconWidth + db.ColumnSpacing
---   aura_grid.AuraHeight = db.IconHeight + db.RowSpacing
---   aura_grid.RowSpacing = db.RowSpacing
---   aura_grid.ColumnSpacing = db.ColumnSpacing
-
---   aura_grid.AuraWidgetWidth = (db.IconWidth * db.Columns) + (db.ColumnSpacing * db.Columns) - db.ColumnSpacing + (aura_grid.AuraWidgetOffset * 2)
---   aura_grid.AuraWidgetHeight = (db.IconHeight * db.Rows) + (db.RowSpacing * db.Rows) - db.RowSpacing + (aura_grid.AuraWidgetOffset * 2)
-
---   for i = 1, db.Columns do
---     local active_auras_width = (db.IconWidth * i) + (db.ColumnSpacing * i) - db.ColumnSpacing + (aura_grid.AuraWidgetOffset * 2)
---     aura_grid.CenterAurasPositions[i] = (aura_grid.AuraWidgetWidth - active_auras_width) / 2
---   end
--- end
-
-function Widget:UpdateSettingsIconMode(aura_type, filter)
-  local aura_grid = self[aura_type]
-
-  local db = self.db[aura_type].ModeIcon
-  aura_grid.db = db
-  aura_grid.db_widget = self.db
-
-  aura_grid.UpdateInterval = Addon.ON_UPDATE_INTERVAL
-  aura_grid.AlignLayout = GRID_LAYOUT[self.db[aura_type].AlignmentH][self.db[aura_type].AlignmentV]
-
-  aura_grid.Columns = db.Columns
-  aura_grid.MaxAuras = min(db.MaxAuras, db.Rows * db.Columns)
-
-  aura_grid.AuraWidgetOffset = (self.db.ShowAuraType and 2) or 1
-
-  aura_grid.AuraWidth = db.IconWidth + db.ColumnSpacing
-  aura_grid.AuraHeight = db.IconHeight + db.RowSpacing
-  aura_grid.RowSpacing = db.RowSpacing
-  aura_grid.ColumnSpacing = db.ColumnSpacing
-
-  aura_grid.AuraWidgetWidth = (db.IconWidth * db.Columns) + (db.ColumnSpacing * db.Columns) - db.ColumnSpacing + (aura_grid.AuraWidgetOffset * 2)
-  aura_grid.AuraWidgetHeight = (db.IconHeight * db.Rows) + (db.RowSpacing * db.Rows) - db.RowSpacing + (aura_grid.AuraWidgetOffset * 2)
-
-  for i = 1, db.Columns do
-    local active_auras_width = (db.IconWidth * i) + (db.ColumnSpacing * i) - db.ColumnSpacing + (aura_grid.AuraWidgetOffset * 2)
-    aura_grid.CenterAurasPositions[i] = (aura_grid.AuraWidgetWidth - active_auras_width) / 2
-  end
-
-  aura_grid.CreateAuraFrame = CreateAuraFrameIconMode
-  aura_grid.UpdateAuraFrame = UpdateAuraFrameIconMode
-  aura_grid.UpdateAuraInformation = UpdateAuraInformationIconMode
-  aura_grid.UpdateWidgetTime = UpdateWidgetTimeIconMode
-
-  aura_grid.Create = CreateAuraGrid
-  aura_grid.GetAuraFrame = GetAuraFrame
-  aura_grid.UpdateAuraFramePosition = UpdateAuraFramePosition
-  aura_grid.HideNonActiveAuras = HideNonActiveAuras
-end
-
-
--- function Widget:UpdateSizeDataBarMode(aura_grid, db)
---   aura_grid.AuraWidth = db.BarWidth
---   aura_grid.AuraHeight = db.BarHeight + db.BarSpacing
---   aura_grid.RowSpacing = db.BarSpacing
---   aura_grid.ColumnSpacing = 0
-
---   if db.ShowIcon then
---     aura_grid.AuraWidgetWidth = db.BarWidth + db.BarHeight + db.IconSpacing
---   else
---     aura_grid.AuraWidgetWidth = db.BarWidth
---   end
---   aura_grid.AuraWidgetHeight = (db.BarHeight * db.MaxBars) + (db.BarSpacing * db.MaxBars) - db.BarSpacing + (aura_grid.AuraWidgetOffset * 2)
--- end
-
-function Widget:UpdateSettingsBarMode(aura_type, filter)
-  local aura_grid = self[aura_type]
-
-  local db = self.db[aura_type].ModeBar
-  aura_grid.db = db
-  aura_grid.db_widget = self.db
-
-  aura_grid.UpdateInterval = 1 / GetFramerate()
-  aura_grid.AlignLayout = GRID_LAYOUT[self.db[aura_type].AlignmentH][self.db[aura_type].AlignmentV]
-
-  aura_grid.Columns = 1
-  aura_grid.MaxAuras = db.MaxBars
-
-  aura_grid.AuraWidgetOffset = 0
-
-  aura_grid.AuraWidth = db.BarWidth
-  aura_grid.AuraHeight = db.BarHeight + db.BarSpacing
-  aura_grid.RowSpacing = db.BarSpacing
-  aura_grid.ColumnSpacing = 0
-
-  if db.ShowIcon then
-    aura_grid.AuraWidgetWidth = db.BarWidth + db.BarHeight + db.IconSpacing
-  else
-    aura_grid.AuraWidgetWidth = db.BarWidth
-  end
-  aura_grid.AuraWidgetHeight = (db.BarHeight * db.MaxBars) + (db.BarSpacing * db.MaxBars) - db.BarSpacing + (aura_grid.AuraWidgetOffset * 2)
-
-  aura_grid.CreateAuraFrame = CreateAuraFrameBarMode
-  aura_grid.UpdateAuraFrame = UpdateAuraFrameBarMode
-  aura_grid.UpdateAuraInformation = UpdateAuraInformationBarMode
-
-  if ShowDuration then
-    aura_grid.UpdateWidgetTime = UpdateWidgetTimeBarMode
-  else
-    aura_grid.UpdateWidgetTime = UpdateWidgetTimeBarMode
-  end
-
-  aura_grid.Create = CreateAuraGrid
-  aura_grid.GetAuraFrame = GetAuraFrame
-  aura_grid.UpdateAuraFramePosition = UpdateAuraFramePosition
-  aura_grid.HideNonActiveAuras = HideNonActiveAuras
-end
 
 -- Load settings from the configuration which are shared across all aura widgets
 -- used (for each widget) in UpdateWidgetConfig
 function Widget:UpdateSettings()
   self.db = Addon.db.profile.AuraWidget
 
-  self.Buffs.IconMode = not self.db.Buffs.ModeBar.Enabled
-  self.Debuffs.IconMode = not self.db.Debuffs.ModeBar.Enabled
-  self.CrowdControl.IconMode = not self.db.CrowdControl.ModeBar.Enabled
-
-  if self.Buffs.IconMode then
-    self:UpdateSettingsIconMode("Buffs")
-  else
-    self:UpdateSettingsBarMode("Buffs")
-  end
-
-  if self.Debuffs.IconMode then
-    self:UpdateSettingsIconMode("Debuffs")
-  else
-    self:UpdateSettingsBarMode("Debuffs")
-  end
-
-  if self.CrowdControl.IconMode then
-    self:UpdateSettingsIconMode("CrowdControl")
-  else
-    self:UpdateSettingsBarMode("CrowdControl")
-  end
-
-  -- local buffs_size = (self.Buffs.IconMode and max(self.db.Buffs.ModeIcon.IconWidth, self.db.Buffs.ModeIcon.IconHeight)) or self.db.Buffs.ModeBar.BarHeight
-  -- local debuffs_size = (self.Debuffs.IconMode and max(self.db.Debuffs.ModeIcon.IconWidth, self.db.Debuffs.ModeIcon.IconHeight)) or self.db.Debuffs.ModeBar.BarHeight
-
-  -- self.SwitchScaleBuffsFactor = debuffs_size/ buffs_size
-  -- self.SwitchScaleDebuffsFactor = buffs_size / debuffs_size
-
-  self:ParseSpellFilters()
-
-  SetNoCooldownCount = OmniCC and OmniCC.Cooldown and OmniCC.Cooldown.SetNoCooldownCount
   HideOmniCC = not self.db.ShowOmniCC or Addon.ExpansionIsAtLeastMidnight
-
   ShowDuration = self.db.ShowDuration and HideOmniCC
-  --  -- Don't update any widget frame if the widget isn't enabled.
---  if not self:IsEnabled() then return end
-
-  -- Highlighting
-  AuraHighlightEnabled = self.db.Highlight.Enabled
-  local glow_function = CUSTOM_GLOW_FUNCTIONS[self.db.Highlight.Type][1]
-  AuraHighlightStart = CUSTOM_GLOW_WRAPPER_FUNCTIONS[glow_function] or Addon.LibCustomGlow[glow_function]
-  AuraHighlightStopPrevious = AuraHighlightStop or Addon.LibCustomGlow.PixelGlow_Stop
-  AuraHighlightStop = Addon.LibCustomGlow[CUSTOM_GLOW_FUNCTIONS[self.db.Highlight.Type][2]]
-  AuraHighlightOffset = CUSTOM_GLOW_FUNCTIONS[self.db.Highlight.Type][3]
-
-  local color = (self.db.Highlight.CustomColor and self.db.Highlight.Color) or Addon.DEFAULT_SETTINGS.profile.AuraWidget.Highlight.Color
-  AuraHighlightColor[1] = color.r
-  AuraHighlightColor[2] = color.g
-  AuraHighlightColor[3] = color.b
-  AuraHighlightColor[4] = color.a
 
   EnabledForStyle["NameOnly"] = self.db.ShowInHeadlineView
   EnabledForStyle["NameOnly-Unique"] = self.db.ShowInHeadlineView
@@ -1624,153 +727,19 @@ function Widget:UpdateSettings()
   EnabledForStyle["unique"] = self.db.ON
   EnabledForStyle["etotem"] = false
   EnabledForStyle["empty"] = false
-
-  local sort_function = SORT_FUNCTIONS[self.db.SortOrder]
-  if sort_function then  
-    SortFunction = sort_function[self.db.SortReverse and "Reverse" or "Default"]
-  else
-    SortFunction = nil
-  end
 end
 
 ---------------------------------------------------------------------------------------------------
--- Configuration Mode
+-- Configuration Mode / Debug - stubs only, kept so external call sites (Options.lua's
+-- "Configuration Mode" toggle, Commands.lua's "/tptp debug Auras ...") don't error. Neither the
+-- demo/preview aura fabrication nor the debug aura dump has an equivalent hook into AuraContainer
+-- (Blizzard owns aura fetching internally via SetUnit() on a real unit token).
 ---------------------------------------------------------------------------------------------------
-
-local EnabledConfigMode = false
-local Timer
-
-local ConfigModeAuras = {
-  HARMFUL = {},
-  HELPFUL = {}
-}
-
-local DEMO_AURA_ICONS = {
-  Buffs = { 136085, 132179, 135869, 135962, 135902, 136205, 136114, 136148, 132333 },
-  Debuffs = { 132122, 132212, 135812, 135959, 136207, 132273, 135813, 136118, 132155 },
-  CrowdControl = { 132114, 132118, 136071, 135963, 136184, 136175, 135849, 136183, 132316 },
-}
-
-local function GenerateDemoAuras()
-  for no = 1, 40 do
-    -- aura.name, aura.icon, aura.applications, aura.dispelName, aura.duration, aura.expirationTime, aura.sourceUnit,
-    -- aura.isStealable, aura.nameplateShowPersonal, aura.spellId, aura.canApplyAura, aura.isBossAura, _, aura.nameplateShowAll =
-    local random_name = tostring(math.random(1, 40))
-
-    local aura_duration = math.random(3, 120)
-    local aura_expiration = GetTime() + aura_duration
-    local aura_name, aura_texture, aura_stacks, aura_type, aura_caster, aura_spellid, aura_steal, aura_show_all
-    if no % 2 == 0 then
-      aura_name = "Rake" .. random_name
-      aura_texture = DEMO_AURA_ICONS.Debuffs[math.random(1, #DEMO_AURA_ICONS.Debuffs)]
-      aura_stacks, aura_type, aura_caster, aura_spellid, aura_steal, aura_show_all = 3, nil, "player", 1822, false, false
-    else
-      aura_name = "Bash" .. random_name
-      aura_texture = DEMO_AURA_ICONS.CrowdControl[math.random(1, #DEMO_AURA_ICONS.CrowdControl)]
-      aura_stacks, aura_type, aura_caster, aura_spellid, aura_steal, aura_show_all = 2, nil, "player", 5211, false, true
-    end
-    ConfigModeAuras.HARMFUL[no] = { aura_name, aura_texture, aura_stacks, aura_type, aura_duration, aura_expiration, aura_caster, aura_steal, false, aura_spellid, true, false, true, aura_show_all, 1 }
-
-    aura_name = "Regrowth" .. random_name
-    aura_expiration = GetTime() + aura_duration
-    aura_texture = DEMO_AURA_ICONS.Buffs[math.random(1, #DEMO_AURA_ICONS.Buffs)]
-    aura_stacks, aura_type, aura_caster, aura_spellid, aura_steal = 5, "Magic", "nameplate1", 8936, no % 5 == 0
-    ConfigModeAuras.HELPFUL[no] = { aura_name, aura_texture, aura_stacks, aura_type, aura_duration, aura_expiration, aura_caster, aura_steal, false, aura_spellid, true, false, true, false, 1 }
-  end
-end
-
-local function TimerCallback()
-  for no = 40, 1, -1 do
-    local aura = ConfigModeAuras.HARMFUL[no]
-    if aura and aura[6] < GetTime() then
-      table.remove(ConfigModeAuras.HARMFUL, no)
-    end
-    aura = ConfigModeAuras.HELPFUL[no]
-    if aura and aura[6] < GetTime() then
-      table.remove(ConfigModeAuras.HELPFUL, no)
-    end
-  end
-
-  if #ConfigModeAuras.HARMFUL + #ConfigModeAuras.HELPFUL == 0 then
-    GenerateDemoAuras()
-  end
-
-  for _, tp_frame in Addon:GetActiveThreatPlates() do
-    Widget:UpdateAuras(tp_frame.widgets.Auras, tp_frame.unit)
-  end
-end
-
-local function UnitAuraForConfigurationMode(unitid, i, effect)
-  local aura = ConfigModeAuras[effect][i]
-  if aura then
-    return unpack(aura)
-  else
-    return nil
-  end
-end
-
-local function ProcessAllUnitAurasConfigMode(unitid, effect)
-  local unit_auras = {}
-
-  for i = 1, 40 do
-    local aura = {}
-
-    aura.name, aura.icon, aura.applications, aura.dispelName, aura.duration, aura.expirationTime, aura.sourceUnit,
-      aura.isStealable, aura.nameplateShowPersonal, aura.spellId, aura.canApplyAura, aura.isBossAura, aura.castByPlayer, aura.nameplateShowAll =
-      UnitAuraForConfigurationMode(unitid, i, effect)
-
-    if aura.name then 
-      aura.auraInstanceID = i
-      unit_auras[#unit_auras + 1] = aura
-    else
-      break
-    end
-  end
-
-  return unit_auras
-end
-
-local ProcessAllUnitAurasBackup
 
 function Widget:ToggleConfigurationMode()
-  if not EnabledConfigMode then
-    EnabledConfigMode = true
-
-    GenerateDemoAuras()
-    ProcessAllUnitAurasBackup = ProcessAllUnitAuras
-    ProcessAllUnitAuras = ProcessAllUnitAurasConfigMode
-
-    Addon:ForceUpdate()
-    Timer = C_Timer.NewTicker(0.5, TimerCallback)
-  else
-    EnabledConfigMode = false
-
-    ProcessAllUnitAuras = ProcessAllUnitAurasBackup
-    Timer:Cancel()
-
-    Addon:ForceUpdate()
-  end
+  Addon.Logging.Debug("    Auras: configuration/preview mode is not available with AuraContainer.")
 end
 
-local ProcessAllUnitAuras_NoDebug = ProcessAllUnitAuras
-
 function Widget:PrintDebug(command)
-  if command == "enable" then
-    Addon.Logging.Debug("    Debugging mode enabled.")
-    ProcessAllUnitAuras_NoDebug = ProcessAllUnitAuras
-    ProcessAllUnitAuras = function(unitid, effect)
-      local unit_auras = ProcessAllUnitAuras_NoDebug(unitid, effect)
-      
-      for k, aura in pairs(unit_auras) do
-        if aura.sourceUnit == "player" then
-          Addon.Logging.Debug("    Aura:", aura.name, "=> ID:", aura.spellId, "( Dispell:", aura.isStealable, ")")
-        end
-      end
-
-      return unit_auras
-    end
-  else
-    Addon.Logging.Debug("    Debugging mode disabled.")
-    ProcessAllUnitAuras = ProcessAllUnitAuras_NoDebug
-  end
+  Addon.Logging.Debug("    Auras: per-aura debug dump is not available with AuraContainer.")
 end

--- a/Widgets/AurasWidgetMidnight.lua
+++ b/Widgets/AurasWidgetMidnight.lua
@@ -114,12 +114,12 @@ local AURA_GROUP_KEYS = {
 }
 local DISPEL_TYPE_NAMES = { "Curse", "Disease", "Magic", "Poison" } -- index matches Debuffs.FilterByType[1..4]
 
--- Dispel-type border coloring (AuraWidget.ShowAuraType/DefaultBuffColor/DefaultDebuffColor, shared
--- across Buffs/Debuffs/CrowdControl - see Constants.lua). AddDispelTypeTexture's customDispelColorMap
--- wants real Color objects (needs :GetRGBA()), not the plain {r=,g=,b=} tables _G.DebuffTypeColor (or
--- the legacy AurasWidget.lua fallback of the same shape) provides - built once here. customDispelColorCurve
--- (a C_CurveUtil color curve) is the alternative Blizzard also supports, but customDispelColorMap is a
--- plain name->color table and needs no curve object to reconstruct, so it's used here instead.
+-- Dispel-type border coloring (AuraWidget.ShowAuraType, shared across Buffs/Debuffs/CrowdControl -
+-- see Constants.lua). AddDispelTypeTexture's customDispelColorMap wants real Color objects (needs
+-- :GetRGBA()), not the plain {r=,g=,b=} tables _G.DebuffTypeColor (or the legacy AurasWidget.lua
+-- fallback of the same shape) provides - built once here. customDispelColorCurve (a C_CurveUtil color
+-- curve) is the alternative Blizzard also supports, but customDispelColorMap is a plain name->color
+-- table and needs no curve object to reconstruct, so it's used here instead.
 local function BuildDispelTypeColorMap()
   local source = _G.DebuffTypeColor or {
     Magic = { r = 0.20, g = 0.60, b = 1.00 },
@@ -139,6 +139,25 @@ end
 
 local DISPEL_TYPE_COLOR_MAP = BuildDispelTypeColorMap()
 
+-- customDispelColorMap's lookup key for an aura with no dispel type is the literal string "None"
+-- (Blizzard_CustomAuraButton.lua's GetDispelTypeMapKey: `auraData.dispelName or "None"`) - adding a
+-- "None" entry here is what lets AuraWidget.DefaultBuffColor/DefaultDebuffColor (Options: Appearance
+-- -> Highlight -> Buff/Debuff Color) actually take effect, matching the legacy widget's
+-- Widget:GetColorForAura (DebuffTypeColor[dispelName] or DefaultDebuffColor for harmful auras,
+-- DefaultBuffColor otherwise). Built per aura_type (not once globally, unlike DISPEL_TYPE_COLOR_MAP
+-- above) since Buffs vs. Debuffs/CrowdControl need a different default color - CrowdControl auras are
+-- always harmful, so they share Debuffs' DefaultDebuffColor, same as the legacy widget's
+-- `aura.effect == "HARMFUL"` check.
+local function GetDispelTypeColorMapForAuraType(aura_type)
+  local map = {}
+  for dispel_name, color in pairs(DISPEL_TYPE_COLOR_MAP) do
+    map[dispel_name] = color
+  end
+  local default_color = (aura_type == "Buffs") and Widget.db.DefaultBuffColor or Widget.db.DefaultDebuffColor
+  map.None = _G.CreateColor(default_color.r, default_color.g, default_color.b, default_color.a or 1)
+  return map
+end
+
 local AuraContainerPool = { Buffs = {}, Debuffs = {}, CrowdControl = {} }
 local NextAuraContainerIndex = { Buffs = 1, Debuffs = 1, CrowdControl = 1 }
 
@@ -151,9 +170,10 @@ local function InitializeAuraButton(auraButton, aura_type)
   auraButton:SetIcon(auraButton.Icon)
 
   if Widget.db.ShowAuraType then
-    -- Border style + showWithoutDispelType=false: only draws when the aura actually has a dispel
-    -- type (most buffs don't), colored via customDispelColorMap instead of Blizzard's own per-type
-    -- atlas color, matching the legacy widget's DebuffTypeColor-based coloring.
+    -- Border style, always drawn (showWithoutDispelType=true) - dispel-typed auras get their
+    -- DISPEL_TYPE_COLOR_MAP color, everything else falls back to DefaultBuffColor/DefaultDebuffColor
+    -- via the "None" map key (see GetDispelTypeColorMapForAuraType), matching the legacy widget's
+    -- Widget:GetColorForAura (every aura gets some border color, not just dispel-typed ones).
     auraButton.DispelBorder = auraButton:CreateTexture(nil, "OVERLAY")
     -- PixelUtil (not plain SetPoint) so the outset is a crisp, consistent number of screen pixels
     -- regardless of UI scale - a plain SetPoint offset could land sub-pixel and look like it's not
@@ -164,8 +184,8 @@ local function InitializeAuraButton(auraButton, aura_type)
       style = _G.Enum.CustomAuraButtonDispelTypeTextureStyle.Border,
       showWhenHarmful = true,
       showWhenHelpful = true,
-      showWithoutDispelType = false,
-      customDispelColorMap = DISPEL_TYPE_COLOR_MAP,
+      showWithoutDispelType = true,
+      customDispelColorMap = GetDispelTypeColorMapForAuraType(aura_type),
     })
   end
 

--- a/Widgets/AurasWidgetMidnight.lua
+++ b/Widgets/AurasWidgetMidnight.lua
@@ -211,10 +211,19 @@ local function InitializeAuraButton(auraButton, aura_type)
     auraButton:SetDurationText(auraButton.TimeLeft)
   end
 
-  -- AuraButton tooltips are managed by Blizzard automatically; no AuraFrameOnEnter/GameTooltip code
-  -- needed on our side, just whether mouse interaction is enabled at all.
+  -- AuraButton tooltips are managed by Blizzard automatically (OnEnter/OnLeave are intrinsic, wired
+  -- in Blizzard_AuraButton.xml, not addon-scriptable) - but ShowTooltip() calls
+  -- tooltip:SetOwner(self, self:GetTooltipAnchorPoint()), and GetTooltipAnchorPoint() returns
+  -- self.tooltipAnchorPoint, which is nil until SetTooltipAnchorPoint() is called at least once
+  -- (OnLoad_Intrinsic never initializes it). Without this, SetOwner got a nil anchor and no tooltip
+  -- ever appeared - confirmed by user report ("mouse over aura shows nothing") even with ShowTooltips
+  -- enabled and SetMouseMotionEnabled/SetHideTooltipInCombat both correctly set.
+  -- false, not true: Blizzard's own default unit-frame auras still show tooltips in combat (verified
+  -- live by user), so hiding ours in combat was an unnecessary restriction, not something matching
+  -- Blizzard's own behavior.
+  auraButton:SetTooltipAnchorPoint("ANCHOR_RIGHT")
   auraButton:SetMouseMotionEnabled(Widget.db.ShowTooltips)
-  auraButton:SetHideTooltipInCombat(true)
+  auraButton:SetHideTooltipInCombat(false)
 
   PixelUtil.SetSize(auraButton, db_icon.IconWidth, db_icon.IconHeight)
 end

--- a/Widgets/AurasWidgetMidnight.lua
+++ b/Widgets/AurasWidgetMidnight.lua
@@ -63,8 +63,10 @@ local EnabledForStyle = {}
 --   ShowOn*NPCs always short-circuit into a single unrestricted group first, though - "All on NPCs" is
 --   conceptually "All, but scoped to NPCs", not a peer condition, and can't be freely combined with
 --   the others the normal way (no candidateFilters field for "unit is an NPC" to cross-exclude it
---   with). Debuffs additionally supports MaxDuration (enemy only) as an AND-restriction on top of
---   whichever OR-condition(s) are active. CrowdControl (either reaction) is still single-condition
+--   with). Buffs (both reactions) additionally supports MaxDuration as an AND-restriction on top of
+--   whichever OR-condition(s) are active - filters out permanent/long-duration passive buffs (flasks,
+--   food, Well Fed, ...); not offered on Debuffs, where a duration cap is rarely useful. CrowdControl
+--   (either reaction) is still single-condition
 --   only (All vs. Dispellable, a plain "elseif") - not converted to the multi-group pattern.
 -- - A crowd-control-classified aura is strictly exclusive to the CrowdControl grid (filtered out of
 --   Debuffs via "!CROWD_CONTROL"); the old per-aura fallback (show as a normal debuff if the
@@ -77,11 +79,15 @@ local EnabledForStyle = {}
 -- - Per-spell FilterBySpell (spell name/ID text list) is not implemented; candidateFilters.
 --   includeSpellIDs/excludeSpellIDs would only be usable for Debuffs+CrowdControl on enemies anyway
 --   (Blizzard restricts spell-ID candidate filters to helpful-on-assistable/harmful-on-non-assistable).
--- - Visual settings (font/size/tooltip/stack count/duration text visibility, including whether the
---   dispel-type border is drawn at all via ShowAuraType) are only applied once, at pool-creation time
---   - changing them in Options during the same session does not re-skin
---   already-pooled AuraButtons (Forbidden Aspects mean there is no per-aura Lua hook to reapply
---   style on demand, unlike the old manual icon-frame system).
+-- - Icon size, tooltip-enable, and cooldown-spiral visibility DO propagate live to already-pooled
+--   AuraButtons (see ReapplyLiveAuraButtonSettings, called from Widget:UpdateSettings) - none of
+--   AuraButton's ForbiddenAspects block plain Set* calls, and GetAuraGroupFrame/GetAuraGroupFrameCount
+--   are real addon-facing methods to reach already-created buttons. Stack count/duration text
+--   visibility, their font/size/color, and whether the dispel-type border is drawn at all
+--   (ShowAuraType) are still create-time-only, though - those conditionally *create* child textures/
+--   fontstrings once at InitializeAuraButton time (FontUpdateText is likewise only ever called there),
+--   and there is no retroactive create/destroy/re-font path for that here - changing any of those in
+--   Options during the same session only takes effect on newly-pooled buttons, not already-pooled ones.
 -- - The demo/preview "Configuration Mode" and the aura-trigger custom-plate-style system (both
 --   already non-functional prior to this) have no equivalent hook into AuraContainer and remain
 --   unavailable.
@@ -103,7 +109,7 @@ local AURA_CONTAINER_TYPES = { "Buffs", "Debuffs", "CrowdControl" }
 -- GetFriendlyBuffsGroupConfigs); Buffs (enemy) and CrowdControl (either reaction) only ever use "main".
 local AURA_GROUP_KEYS = {
   Buffs = { "main", "canapply", "bigdefensive", "dispellable", "magic" },
-  Debuffs = { "main", "important", "boss", "priority", "dispellable", "dispeltype" },
+  Debuffs = { "main", "important", "importantpersonal", "boss", "priority", "dispellable", "dispeltype" },
   CrowdControl = { "main" },
 }
 local DISPEL_TYPE_NAMES = { "Curse", "Disease", "Magic", "Poison" } -- index matches Debuffs.FilterByType[1..4]
@@ -191,6 +197,45 @@ local function InitializeAuraButton(auraButton, aura_type)
   auraButton:SetHideTooltipInCombat(true)
 
   PixelUtil.SetSize(auraButton, db_icon.IconWidth, db_icon.IconHeight)
+end
+
+-- Icon size, tooltip-enable, and cooldown-spiral-visibility are the subset of InitializeAuraButton's
+-- settings that CAN be safely reapplied to already-created AuraButtons after the fact - they're plain
+-- Set* calls, and none of the AuraButton's ForbiddenAspects (UntrustedScriptExecution,
+-- ChangeParent, ... - see Blizzard_AuraButton.xml) block them. Unlike StackCount/Duration/dispel
+-- border above, which are conditionally *created* once at InitializeAuraButton time and have no
+-- retroactive create/destroy path here, so still only take effect on newly-pooled buttons.
+-- GetAuraGroupFrame/GetAuraGroupFrameCount are real addon-facing AuraContainer methods (not
+-- Forbidden), so every already-created button - active or currently unused/available in the pool -
+-- can be reached and re-styled. Called from Widget:UpdateSettings so changing IconWidth/IconHeight/
+-- ShowTooltips/ShowCooldownSpiral in Options actually takes effect immediately, not just for auras
+-- created after the change.
+--
+-- AuraButton carries AccessRestrictionFlags = DenyTaintedAccessWhenAurasAreSecret
+-- (Blizzard_AuraContainerShared.lua), and this call happens from plain (tainted) addon code, unlike
+-- InitializeAuraButton's initial Set* calls, which run inside Blizzard's own securecallfunction
+-- wrapper (Blizzard_AuraContainerFrameProviders.lua:79) and are therefore not tainted. Rather than
+-- risk that restriction denying/erroring on individual buttons, deferred via Addon.ExecuteAfterCombatEnds
+-- like every other setting this addon can't safely change mid-combat - warns once and re-runs
+-- automatically after combat ends instead of silently doing nothing until the next settings change.
+local function ReapplyLiveAuraButtonSettings(aura_type)
+  if not HasAuraContainers then return end
+
+  Addon.ExecuteAfterCombatEnds(function()
+    local db_icon = Widget.db[aura_type].ModeIcon
+    for _, container in ipairs(AuraContainerPool[aura_type]) do
+      for _, group_key in ipairs(AURA_GROUP_KEYS[aura_type]) do
+        for i = 1, container:GetAuraGroupFrameCount(group_key) do
+          local auraButton = container:GetAuraGroupFrame(group_key, i)
+          PixelUtil.SetSize(auraButton, db_icon.IconWidth, db_icon.IconHeight)
+          auraButton:SetMouseMotionEnabled(Widget.db.ShowTooltips)
+          if auraButton.Cooldown then
+            auraButton.Cooldown:SetShownSwipe(Widget.db.ShowCooldownSpiral, HideOmniCC)
+          end
+        end
+      end
+    end
+  end, "Unable to update the appearance of auras while in combat.")
 end
 
 -- Maps the widget's SortOrder setting to the closest AuraContainerSortMethod. Duration/Creation have
@@ -332,8 +377,15 @@ end
 -- auras on NPC targets). Otherwise Mine/PlayerCanApply/BigDefensives are independent,
 -- freely-combinable OR-conditions.
 local function GetFriendlyBuffsGroupConfigs(db, unit)
+  -- MaxDuration (Patch 12.1.0): non-nil implicitly hides permanent buffs too, per Blizzard's own
+  -- documentation - applied as an extra AND-restriction on every active group below (not its own
+  -- OR-condition/group), regardless of which other toggle(s) are active. Makes more sense here than
+  -- on Debuffs (where it originally lived) - hiding long-duration/permanent auras is mainly useful for
+  -- filtering out passive self-buffs (flasks, food, Well Fed, ...), not debuffs.
+  local max_duration = (db.MaxDurationFriendly and db.MaxDurationFriendly > 0) and db.MaxDurationFriendly or nil
+
   if db.ShowAllFriendly or (db.ShowOnFriendlyNPCs and unit.type == "NPC") then
-    return { main = { filterString = "HELPFUL|" .. NAMEPLATE_ONLY, candidateFilters = {} } }
+    return { main = { filterString = "HELPFUL|" .. NAMEPLATE_ONLY, candidateFilters = { maxDuration = max_duration } } }
   end
 
   local conditions = {}
@@ -347,14 +399,22 @@ local function GetFriendlyBuffsGroupConfigs(db, unit)
     conditions[#conditions + 1] = { key = "bigdefensive", filterTokens = { "BIG_DEFENSIVE" }, candidateFilters = {} }
   end
 
-  return BuildGroupConfigsFromConditions(conditions, { "HELPFUL", NAMEPLATE_ONLY })
+  local configs = BuildGroupConfigsFromConditions(conditions, { "HELPFUL", NAMEPLATE_ONLY })
+  for _, config in pairs(configs) do
+    config.candidateFilters.maxDuration = max_duration
+  end
+
+  return configs
 end
 
 -- Buffs (enemy): same pattern as Friendly above - ShowAllEnemy/ShowOnEnemyNPCs short-circuit,
--- Dispellable/Magic are independent, freely-combinable OR-conditions.
+-- Dispellable/Magic are independent, freely-combinable OR-conditions. MaxDurationEnemy is the
+-- separate enemy-reaction field - see the comment on MaxDurationFriendly in GetFriendlyBuffsGroupConfigs.
 local function GetEnemyBuffsGroupConfigs(db, unit)
+  local max_duration = (db.MaxDurationEnemy and db.MaxDurationEnemy > 0) and db.MaxDurationEnemy or nil
+
   if db.ShowAllEnemy or (db.ShowOnEnemyNPCs and unit.type == "NPC") then
-    return { main = { filterString = "HELPFUL|" .. NAMEPLATE_ONLY, candidateFilters = {} } }
+    return { main = { filterString = "HELPFUL|" .. NAMEPLATE_ONLY, candidateFilters = { maxDuration = max_duration } } }
   end
 
   local conditions = {}
@@ -367,7 +427,12 @@ local function GetEnemyBuffsGroupConfigs(db, unit)
     conditions[#conditions + 1] = { key = "magic", filterTokens = {}, candidateFilters = { includeDispelTypes = { Magic = true } } }
   end
 
-  return BuildGroupConfigsFromConditions(conditions, { "HELPFUL", NAMEPLATE_ONLY })
+  local configs = BuildGroupConfigsFromConditions(conditions, { "HELPFUL", NAMEPLATE_ONLY })
+  for _, config in pairs(configs) do
+    config.candidateFilters.maxDuration = max_duration
+  end
+
+  return configs
 end
 
 -- Debuffs (friendly): same multi-group independent-OR-condition pattern as Debuffs (enemy) below,
@@ -418,9 +483,11 @@ end
 
 -- Builds the full set of AddAuraGroup configs (per AURA_GROUP_KEYS.Debuffs key) for enemy-reaction
 -- Debuffs from today's boolean settings. ShowAllEnemy short-circuits everything into "main" alone.
--- Otherwise each of ShowOnlyMine ("main"), ShowBlizzardForEnemy ("important", candidateFilters.nameplateShowAll),
--- ShowBoss ("boss", candidateFilters.isBossAura), and ShowPriority ("priority",
--- candidateFilters.isPriorityAura) is an independent, freely-combinable OR-condition: every group's
+-- Otherwise each of ShowOnlyMine ("main"), ShowBlizzardForEnemy ("important", candidateFilters.nameplateShowAll
+-- - always further restricted to PLAYER too, by deliberate design: "Blizzard" means "Blizzard-flagged
+-- debuffs I applied", not "anyone's" - see the comment at its condition below), ShowBoss ("boss",
+-- candidateFilters.isBossAura), and ShowPriority ("priority", candidateFilters.isPriorityAura) is an
+-- independent, freely-combinable OR-condition: every group's
 -- filter string/candidateFilters excludes every *earlier-listed* active condition (see
 -- BuildGroupConfigsFromConditions), so an aura matching more than one toggle is always assigned to
 -- exactly one group - the earliest one it satisfies - instead of showing twice or (with the naive
@@ -436,13 +503,8 @@ end
 -- Returns a table keyed by group name -> { filterString = ..., candidateFilters = ... }; a group
 -- key that's missing from the result means "disable this group" (caller sets maxFrameCount to 0).
 local function GetEnemyDebuffsGroupConfigs(db)
-  -- maxDuration (Patch 12.1.0): non-nil implicitly hides permanent auras too, per Blizzard's own
-  -- documentation - applied as an extra AND-restriction on every active group below (not its own
-  -- OR-condition/group), regardless of which other toggle(s) are active.
-  local max_duration = (db.MaxDuration and db.MaxDuration > 0) and db.MaxDuration or nil
-
   if db.ShowAllEnemy then
-    return { main = { filterString = "HARMFUL|!CROWD_CONTROL|" .. NAMEPLATE_ONLY, candidateFilters = { maxDuration = max_duration } } }
+    return { main = { filterString = "HARMFUL|!CROWD_CONTROL|" .. NAMEPLATE_ONLY, candidateFilters = {} } }
   end
 
   local conditions = {}
@@ -460,7 +522,16 @@ local function GetEnemyDebuffsGroupConfigs(db)
     -- combined with HARMFUL here it matched nothing at all - confirmed live by user report.
     -- nameplateShowAll is the real field behind the legacy "Blizzard" toggle's semantics
     -- (aura.nameplateShowAll in AurasWidget.lua) and has no such helpful-only restriction.
-    conditions[#conditions + 1] = { key = "important", filterTokens = {}, candidateFilters = { nameplateShowAll = true } }
+    --
+    -- PLAYER token is hardcoded (not conditional on ShowOnlyMine, unlike the "dispeltype" group's
+    -- PLAYER addition below) - per explicit user decision, "Blizzard" now always means "Blizzard-
+    -- flagged debuffs I applied", not "anyone's". Checking Mine+Blizzard together no longer narrows
+    -- anything further (Mine's own group already shows every debuff the player applied, a superset),
+    -- but that tradeoff was accepted deliberately: an unconditional PLAYER token here is the only way
+    -- to make "Blizzard" alone (without Mine also checked) mean "my own Blizzard-relevant debuffs"
+    -- instead of "everyone's" - the previous, broader meaning is gone entirely, not just narrowed
+    -- when combined with Mine.
+    conditions[#conditions + 1] = { key = "important", filterTokens = { "PLAYER" }, candidateFilters = { nameplateShowAll = true } }
   end
   if db.ShowBossEnemy then
     conditions[#conditions + 1] = { key = "boss", filterTokens = {}, candidateFilters = { isBossAura = true } }
@@ -496,8 +567,26 @@ local function GetEnemyDebuffsGroupConfigs(db)
   end
 
   local configs = BuildGroupConfigsFromConditions(conditions, { "HARMFUL", "!CROWD_CONTROL", NAMEPLATE_ONLY }, dispel_types, has_dispel_type)
-  for _, config in pairs(configs) do
-    config.candidateFilters.maxDuration = max_duration
+
+  -- "Blizzard" is really two conditions ORed together: nameplateShowAll (curated for everyone) and
+  -- nameplateShowPersonal (curated only when self-applied - the field Blizzard's own default
+  -- nameplates also check, per the legacy widget's `aura.nameplateShowAll or (aura.nameplateShowPersonal
+  -- and aura.CastByPlayer)`). A single AddAuraGroup can't express "field A OR field B" - candidateFilters
+  -- entries are ANDed together - so this needs a second, peer group. It can't be pushed through
+  -- BuildGroupConfigsFromConditions as its own condition though: both would need the identical PLAYER
+  -- token, and ordered exclusion would negate the earlier one's token into the later one's filter
+  -- string ("PLAYER|!PLAYER" - a self-contradiction that matches nothing). Instead, clone "important"'s
+  -- already-fully-excluded result (same exclusions against Mine/Boss/Priority/dispeltype) and swap
+  -- nameplateShowAll for nameplateShowPersonal - explicitly excluding nameplateShowAll from the clone
+  -- so an aura with both flags set doesn't render via both groups.
+  if configs.important then
+    local personal_candidate_filters = {}
+    for field, value in pairs(configs.important.candidateFilters) do
+      personal_candidate_filters[field] = value
+    end
+    personal_candidate_filters.nameplateShowAll = false
+    personal_candidate_filters.nameplateShowPersonal = true
+    configs.importantpersonal = { filterString = configs.important.filterString, candidateFilters = personal_candidate_filters }
   end
 
   return configs
@@ -798,6 +887,10 @@ function Widget:UpdateSettings()
   EnabledForStyle["unique"] = self.db.ON
   EnabledForStyle["etotem"] = false
   EnabledForStyle["empty"] = false
+
+  for _, aura_type in ipairs(AURA_CONTAINER_TYPES) do
+    ReapplyLiveAuraButtonSettings(aura_type)
+  end
 end
 
 ---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Fix Lua error when displaying auras on nameplates caused by restrictions on secret values [GH-723].
- Rebuilt the Auras widget on top of Patch 12.1.0's new AuraContainer API, since the old aura-scanning method no longer works reliably. Currently only rudimentary aura features are available as a result.

## Test plan
- [ ] `/reload` on a Midnight (12.1) client, Auras widget enabled, confirm no Lua errors in BugSack.
- [ ] Buffs/Debuffs/CrowdControl display correctly for friendly and enemy units, in and out of combat.
- [ ] Check each filter toggle in Options against `Source/Wiki/AurasFilterCriteria.md`.